### PR TITLE
Add brightness support for dimmer-only devices

### DIFF
--- a/custom_components/lednetwf_ble/light.py
+++ b/custom_components/lednetwf_ble/light.py
@@ -272,6 +272,8 @@ class LEDNetWFLight(LightEntity):
                 )
             elif self._device.rgb_color and self._device.has_rgb:
                 await self._device.set_rgb_color(self._device.rgb_color, brightness)
+            elif self._device.has_dim:
+                await self._device.set_brightness(brightness)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -142,6 +142,28 @@ def build_power_command_0x3B(turn_on: bool) -> bytearray:
     return wrap_command(raw_cmd, cmd_family=0x0b)
 
 
+def build_brightness_command_0x3B(brightness_pct: int) -> bytearray:
+    """
+    Build standalone brightness command using 0x3B format.
+
+    Source: ble_dp_cmd.json - bright_value_v2
+    Format: [0x3B, 0x01, 0, 0, bright, 0, bright, delay(3), gradient(2), checksum]
+    Brightness is 0-100 (percent).
+    """
+    brightness_pct = max(0, min(100, brightness_pct))
+    raw_cmd = bytearray([
+        0x3B, 0x01,
+        0x00, 0x00,
+        brightness_pct & 0xFF,
+        0x00,
+        brightness_pct & 0xFF,
+        0x00, 0x00, 0x00,  # Delay (24-bit big-endian)
+        0x00, 0x00          # Gradient (16-bit big-endian)
+    ])
+    raw_cmd.append(calculate_checksum(raw_cmd))
+    return wrap_command(raw_cmd, cmd_family=0x0b)
+
+
 def build_power_command_0x71(turn_on: bool) -> bytearray:
     """
     Build power command using 0x71 format (legacy BLE v1-4).


### PR DESCRIPTION
## Summary
- Adds brightness control for dimmer-only devices (`Ctrl_Dim`, `Bulb_Dim`, `Magnetic_Dim` — product IDs 65, 33, 23) which was previously silently dropped
- Uses the `0x3B 0x01` standalone brightness command (`bright_value_v2`) matching the Zengge app's approach
- Adds state parsing for dimmer devices so reported brightness is read correctly from the R channel

## Detail

Dimmer-only devices have `has_dim: True` in their capability definitions but this flag was never referenced in `device.py` or `light.py`. When a user adjusted the brightness slider, `async_turn_on` received `brightness=N` but all command branches required `has_rgb` or `has_color_temp`, so the value was silently dropped and only power on/off commands were sent.

**Changes:**
- **protocol.py**: New `build_brightness_command_0x3B()` implementing the standalone brightness command from `ble_dp_cmd.json`
- **device.py**: New `has_dim` property, `set_brightness()` method (converts 0-255 to 0-100% for protocol), and dimmer state parsing branch for `mode_type=0x61`
- **light.py**: New `has_dim` branch in `async_turn_on` so brightness changes reach the device

Fixes #79

## Test plan
- [x] Tested by user with Ctrl_Dim (product 0x41) hardware — confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)