### PR TITLE
Restore LED settings config for ring / FillLight (ADDRESSABLE_0x53) devices

### DIFF
--- a/custom_components/lednetwf_ble/__init__.py
+++ b/custom_components/lednetwf_ble/__init__.py
@@ -25,7 +25,9 @@ from .const import (
     DEFAULT_LED_COUNT,
     DEFAULT_SEGMENTS,
     LedType,
+    RingLedType,
     ColorOrder,
+    EffectType,
     get_device_capabilities,
 )
 from .device import LEDNetWFDevice
@@ -181,6 +183,32 @@ async def async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None
                 _LOGGER.warning("Failed to apply IOTBT segment LED settings to device")
         else:
             _LOGGER.debug("IOTBT segment LED settings unchanged, no update needed")
+    elif device.effect_type == EffectType.ADDRESSABLE_0x53:
+        # Ring / FillLight: count + chip type + colour order (single segment),
+        # written via the short 0x62 ring command.
+        new_led_count = entry.options.get(CONF_LED_COUNT, DEFAULT_LED_COUNT)
+        new_led_type = entry.options.get(CONF_LED_TYPE, RingLedType.WS2812B.value)
+        new_color_order = entry.options.get(CONF_COLOR_ORDER, ColorOrder.GRB.value)
+
+        if (device._led_count != new_led_count or
+            device._led_type != new_led_type or
+            device._color_order != new_color_order):
+            _LOGGER.info(
+                "Ring LED settings changed, applying: count=%d, chip=%d, order=%d",
+                new_led_count, new_led_type, new_color_order
+            )
+            success = await device.set_led_settings(
+                new_led_count, new_led_type, new_color_order, 1
+            )
+            if success:
+                device._led_count = new_led_count
+                device._led_type = new_led_type
+                device._color_order = new_color_order
+                _LOGGER.debug("Ring LED settings applied")
+            else:
+                _LOGGER.warning("Failed to apply ring LED settings to device")
+        else:
+            _LOGGER.debug("Ring LED settings unchanged, no update needed")
     elif caps.get("has_ic_config"):
         new_led_count = entry.options.get(CONF_LED_COUNT, DEFAULT_LED_COUNT)
         new_segments = entry.options.get(CONF_SEGMENTS, DEFAULT_SEGMENTS)

--- a/custom_components/lednetwf_ble/config_flow.py
+++ b/custom_components/lednetwf_ble/config_flow.py
@@ -32,8 +32,10 @@ from .const import (
     DEFAULT_LED_COUNT,
     DEFAULT_SEGMENTS,
     LedType,
+    RingLedType,
     ColorOrder,
     SimpleColorOrder,
+    EffectType,
     is_supported_device,
     get_device_capabilities,
     needs_capability_probing,
@@ -384,6 +386,39 @@ class LEDNetWFConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
             })
 
+        # Ring / FillLight (ADDRESSABLE_0x53): LED count + chip type + colour order,
+        # single segment, ring-specific chip-type numbering.
+        elif caps.get("effect_type") == EffectType.ADDRESSABLE_0x53:
+            default_led_count = queried.get("led_count") or DEFAULT_LED_COUNT
+
+            queried_ic_type = queried.get("ic_type")
+            default_led_type = RingLedType.WS2812B.name
+            if queried_ic_type is not None:
+                for lt in RingLedType:
+                    if lt.value == queried_ic_type:
+                        default_led_type = lt.name
+                        break
+
+            queried_color_order = queried.get("color_order")
+            default_color_order = ColorOrder.GRB.name
+            if queried_color_order is not None:
+                for co in ColorOrder:
+                    if co.value == queried_color_order:
+                        default_color_order = co.name
+                        break
+
+            schema_dict.update({
+                vol.Optional(CONF_LED_COUNT, default=default_led_count): NumberSelector(
+                    NumberSelectorConfig(min=1, max=255, mode=NumberSelectorMode.BOX)
+                ),
+                vol.Optional(CONF_LED_TYPE, default=default_led_type): vol.In(
+                    [t.name for t in RingLedType]
+                ),
+                vol.Optional(CONF_COLOR_ORDER, default=default_color_order): vol.In(
+                    [o.name for o in ColorOrder]
+                ),
+            })
+
         # Color order for SIMPLE devices (0x33, etc.) - only RGB, GRB, BRG
         elif caps.get("has_color_order"):
             queried_color_order = self._discovery_info.get("queried_color_order")
@@ -405,6 +440,8 @@ class LEDNetWFConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if caps.get("has_ic_config"):
             total_leds = default_led_count * default_segments
             placeholders["total_leds"] = str(total_leds)
+        elif caps.get("effect_type") == EffectType.ADDRESSABLE_0x53:
+            placeholders["total_leds"] = str(default_led_count)
 
         return self.async_show_form(
             step_id="options",
@@ -448,7 +485,13 @@ class LEDNetWFConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             processed_options[CONF_SEGMENTS] = queried["segments"]
 
         if CONF_LED_TYPE in options:
-            processed_options[CONF_LED_TYPE] = LedType[options[CONF_LED_TYPE]].value
+            # Ring / FillLight devices use the ring-specific chip-type numbering.
+            led_type_enum = (
+                RingLedType
+                if caps.get("effect_type") == EffectType.ADDRESSABLE_0x53
+                else LedType
+            )
+            processed_options[CONF_LED_TYPE] = led_type_enum[options[CONF_LED_TYPE]].value
         elif queried.get("ic_type") is not None:
             processed_options[CONF_LED_TYPE] = queried["ic_type"]
 
@@ -504,6 +547,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # so look at the live device to decide whether to offer LED/segment config.
         device = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
         is_iotbt_segment = bool(device and device.is_iotbt_segment)
+        # ADDRESSABLE_0x53 ring / FillLight devices use a ring-specific LED command.
+        # Prefer the live device's resolved effect type (robust if the entry predates
+        # CONF_PRODUCT_ID being stored), falling back to product capabilities.
+        is_ring = (
+            (device is not None and device.effect_type == EffectType.ADDRESSABLE_0x53)
+            or caps.get("effect_type") == EffectType.ADDRESSABLE_0x53
+        )
 
         schema_dict: dict[vol.Marker, Any] = {
             vol.Optional(
@@ -557,6 +607,35 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ),
             })
 
+        # Ring / FillLight (ADDRESSABLE_0x53): LED count + chip type + colour order.
+        # These devices support a single segment only, so no segments field, and the
+        # chip type uses the ring-specific RingLedType numbering.
+        elif is_ring:
+            current_led_count = options.get(CONF_LED_COUNT, DEFAULT_LED_COUNT)
+            current_led_type = options.get(CONF_LED_TYPE, RingLedType.WS2812B.value)
+            current_color_order = options.get(CONF_COLOR_ORDER, ColorOrder.GRB.value)
+
+            led_type_name = next(
+                (t.name for t in RingLedType if t.value == current_led_type),
+                RingLedType.WS2812B.name,
+            )
+            color_order_name = next(
+                (o.name for o in ColorOrder if o.value == current_color_order),
+                ColorOrder.GRB.name,
+            )
+
+            schema_dict.update({
+                vol.Optional(CONF_LED_COUNT, default=current_led_count): NumberSelector(
+                    NumberSelectorConfig(min=1, max=255, mode=NumberSelectorMode.BOX)
+                ),
+                vol.Optional(CONF_LED_TYPE, default=led_type_name): vol.In(
+                    [t.name for t in RingLedType]
+                ),
+                vol.Optional(CONF_COLOR_ORDER, default=color_order_name): vol.In(
+                    [o.name for o in ColorOrder]
+                ),
+            })
+
         # Color order for SIMPLE devices (0x33, etc.)
         elif caps.get("has_color_order"):
             current_color_order = options.get(CONF_COLOR_ORDER, SimpleColorOrder.GRB.value)
@@ -578,6 +657,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if caps.get("has_ic_config") or is_iotbt_segment:
             total_leds = current_led_count * current_segments
             placeholders["total_leds"] = str(total_leds)
+        elif is_ring:
+            placeholders["total_leds"] = str(current_led_count)
 
         return self.async_show_form(
             step_id="init",
@@ -589,6 +670,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Save options."""
         product_id = self._config_entry.data.get(CONF_PRODUCT_ID)
         caps = get_device_capabilities(product_id)
+        device = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        is_ring = (
+            (device is not None and device.effect_type == EffectType.ADDRESSABLE_0x53)
+            or caps.get("effect_type") == EffectType.ADDRESSABLE_0x53
+        )
 
         new_options = {
             CONF_DISCONNECT_DELAY: user_input.get(
@@ -601,7 +687,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if CONF_SEGMENTS in user_input:
             new_options[CONF_SEGMENTS] = int(user_input[CONF_SEGMENTS])
         if CONF_LED_TYPE in user_input:
-            new_options[CONF_LED_TYPE] = LedType[user_input[CONF_LED_TYPE]].value
+            # Ring / FillLight devices use the ring-specific chip-type numbering.
+            led_type_enum = RingLedType if is_ring else LedType
+            new_options[CONF_LED_TYPE] = led_type_enum[user_input[CONF_LED_TYPE]].value
         if CONF_COLOR_ORDER in user_input:
             color_order_name = user_input[CONF_COLOR_ORDER]
             # Check if it's a SimpleColorOrder (for SIMPLE devices) or ColorOrder (for addressable)

--- a/custom_components/lednetwf_ble/const.py
+++ b/custom_components/lednetwf_ble/const.py
@@ -71,6 +71,22 @@ class ColorOrder(IntEnum):
     BGR = 5
 
 
+class RingLedType(IntEnum):
+    """LED chip types for ADDRESSABLE_0x53 ring / FillLight devices.
+
+    These devices use a DIFFERENT chip-type numbering to the strip/Symphony
+    LedType enum (e.g. WS2811 is 3 here, 5 there), so they need their own map.
+    Values taken from the v1 integration's LedTypes_RingLight, which is what
+    worked on these devices before the v2 rewrite.
+    """
+    WS2812B = 1
+    SM16703 = 2
+    WS2811 = 3
+    UCS1903 = 4
+    SK6812 = 5
+    INK1003 = 6
+
+
 class SimpleColorOrder(IntEnum):
     """RGB color ordering for SIMPLE devices (0x33, etc.).
 

--- a/custom_components/lednetwf_ble/device.py
+++ b/custom_components/lednetwf_ble/device.py
@@ -1811,6 +1811,12 @@ class LEDNetWFDevice:
             packet = protocol.build_iotbt_segment_led_settings_command(
                 led_count, segments
             )
+        elif self.effect_type == EffectType.ADDRESSABLE_0x53:
+            # Ring / FillLight devices: short 0x62 ring command (count + chip + order,
+            # single segment). chip_type uses the ring-specific RingLedType numbering.
+            packet = protocol.build_ring_led_settings_command(
+                led_count, led_type, color_order
+            )
         elif self.has_ic_config:
             # A3+ format with segment support
             packet = protocol.build_led_settings_command_a3(

--- a/custom_components/lednetwf_ble/manifest.json
+++ b/custom_components/lednetwf_ble/manifest.json
@@ -27,5 +27,5 @@
         "bleak-retry-connector>=1.17.1",
         "bleak>=0.17.0"
     ],
-    "version": "2.0.1-beta4"
+    "version": "2.0.1-beta5"
 }

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -616,6 +616,40 @@ def build_iotbt_segment_led_settings_command(
     return wrap_command(raw_cmd, cmd_family=0x0B)
 
 
+def build_ring_led_settings_command(
+    led_count: int, chip_type: int, color_order: int
+) -> bytearray:
+    """
+    Build LED settings command for ADDRESSABLE_0x53 ring / FillLight devices.
+
+    Source: v1 integration (lednetwf.py set_led_settings, RING_LIGHT_MODEL branch),
+    which is what worked on these devices before the v2 rewrite. Payload (6 bytes):
+        62 00 [led_count] [chip_type] [color_order] [checksum]
+
+    Note vs. the strip/Symphony LED-settings commands: this is a short, single-byte
+    led_count payload and supports only one segment. chip_type uses the ring-specific
+    numbering (const.RingLedType), NOT the strip LedType enum.
+
+    The checksum sums the whole payload including color_order (the v1 code summed
+    only up to chip_type; for the common RGB order the two are identical).
+
+    led_count: total LEDs (single byte, 1-255).
+    chip_type: RingLedType value.
+    color_order: ColorOrder value.
+    """
+    led_count = max(1, min(255, led_count))
+
+    raw_cmd = bytearray([
+        0x62, 0x00,
+        led_count & 0xFF,
+        chip_type & 0xFF,
+        color_order & 0xFF,
+    ])
+    raw_cmd.append(calculate_checksum(raw_cmd))
+    # cmd_family 0x0A (expects response) matches the v1 ring packet.
+    return wrap_command(raw_cmd, cmd_family=0x0A)
+
+
 # =============================================================================
 # COLOR COMMANDS
 # =============================================================================


### PR DESCRIPTION
## What

Restores LED-settings configuration (LED count, chip type, colour order) for `ADDRESSABLE_0x53` ring / FillLight devices (e.g. product `0x1D`, the "Circle Light" lamps).

## Why

The v1→v2 rewrite gated LED-settings config on `has_ic_config`, which silently dropped it for `ADDRESSABLE_0x53` devices. They had working LED settings in v1 (commit "LED settings working for rings and strips!"). Symphony A3 controllers (`has_ic_config`) kept theirs, which is why some devices still had the option and the rings didn't.

## How

- `protocol.build_ring_led_settings_command`: rebuilds the **v1 ring payload** `62 00 <count> <chip> <order> <checksum>` (cmd_family `0x0A`). Reproduces the v1 default packet byte-for-byte. Checksum sums the whole payload including colour order (v1 summed only up to chip type; identical for RGB, correct for other orders).
- `const.RingLedType`: ring-specific chip-type numbering, which differs from the strip `LedType` enum (e.g. WS2811 is `3` here vs `5` there), taken from v1's `LedTypes_RingLight`.
- `device.set_led_settings`: routes `ADDRESSABLE_0x53` devices to the ring builder.
- `config_flow`: both the setup flow and the Configure dialog expose LED count + chip type + colour order (single segment, no segments field). Detection prefers the live device's `effect_type`, with product-capability fallback.
- `__init__.async_options_updated`: applies the ring LED settings on save.

## Testing

All builders verified against captured/v1 bytes; the ring default round-trips byte-for-byte (`000080000006070a62000e010071`). Symphony A3 monitors (`has_ic_config`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)