### PR TITLE
Discover devices by name when manufacturer data is absent

### DIFF
--- a/custom_components/lednetwf_ble/config_flow.py
+++ b/custom_components/lednetwf_ble/config_flow.py
@@ -72,10 +72,34 @@ def _parse_discovery(discovery: BluetoothServiceInfoBleak) -> dict | None:
 
     # Parse manufacturer data
     manu_data = protocol.parse_manufacturer_data(discovery.manufacturer_data, name)
-    if not manu_data:
-        return None
+    if manu_data:
+        product_id = manu_data.get("product_id")
+        fw_version = manu_data.get("fw_version")
+    else:
+        # No manufacturer data in this advertisement. This happens under passive
+        # scanning (the manu data sits in a scan response we never see) and for
+        # IOTBT devices that advertise via service data only. Fall back to the
+        # device name, which is in the primary advert and carries the product_id.
+        product_id = protocol.product_id_from_name(name)
+        fw_version = None
 
-    product_id = manu_data.get("product_id")
+        # Only trust a *name-derived* LEDnetWF product_id if it maps to a known
+        # device; otherwise leave it as None so the flow probes capabilities
+        # rather than risk acting on a misparsed id. IOTBT (0x00) is always valid.
+        if product_id not in (None, 0x00):
+            caps = get_device_capabilities(product_id)
+            if not caps or str(caps.get("name", "")).startswith("Unknown"):
+                _LOGGER.debug(
+                    "Device %s: name-derived product 0x%02X is unknown, will probe",
+                    name, product_id,
+                )
+                product_id = None
+
+        _LOGGER.debug(
+            "Device %s has no manufacturer data; identified by name as product %s",
+            name, f"0x{product_id:02X}" if product_id is not None else "unknown (probe)",
+        )
+
     if not is_supported_device(product_id):
         _LOGGER.debug("Device %s (product 0x%02X) not supported", name, product_id or 0)
         return None
@@ -84,7 +108,7 @@ def _parse_discovery(discovery: BluetoothServiceInfoBleak) -> dict | None:
         "address": discovery.address,
         "name": name,
         "product_id": product_id,
-        "fw_version": manu_data.get("fw_version"),
+        "fw_version": fw_version,
         "rssi": discovery.rssi,
     }
 

--- a/custom_components/lednetwf_ble/manifest.json
+++ b/custom_components/lednetwf_ble/manifest.json
@@ -27,5 +27,5 @@
         "bleak-retry-connector>=1.17.1",
         "bleak>=0.17.0"
     ],
-    "version": "2.0.1-beta5"
+    "version": "2.0.1-beta6"
 }

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -1696,6 +1696,44 @@ def parse_led_settings_response_a3(data: bytes) -> dict | None:
     }
 
 
+def product_id_from_name(device_name: str | None) -> int | None:
+    """
+    Best-effort product_id from the advertised device name.
+
+    Used when an advertisement carries no manufacturer data (e.g. passive
+    scanning, or service-data-only IOTBT devices), so the device can still be
+    identified at discovery instead of being silently rejected.
+
+    Two name conventions are handled:
+      - IOTBT* -> product_id 0x00 (IOTBT family; the segment-vs-Telink variant is
+        detected at runtime from service/manufacturer data, not the name).
+      - LEDnetWF long form "LEDnetWF" + 2-char generation + 4-hex product_id +
+        6-hex MAC suffix (20 chars total), e.g. "LEDnetWF02001D0CDA81" -> 0x1D.
+        The 4 hex chars at offset 10:14 match manufacturer-data bytes 8-9.
+
+    Returns the product_id, or None if the name yields nothing recognisable (the
+    caller can then fall back to capability probing).
+    """
+    if not device_name:
+        return None
+
+    upper = device_name.upper()
+
+    # IOTBT family: identified purely by name prefix (same rule as the manufacturer
+    # data path below), product_id is always 0x00.
+    if upper.startswith("IOTBT"):
+        return 0x00
+
+    # LEDnetWF long-name form carries the product_id in the name itself.
+    if upper.startswith("LEDNETWF") and len(device_name) == 20:
+        try:
+            return int(device_name[10:14], 16)
+        except ValueError:
+            return None
+
+    return None
+
+
 def parse_manufacturer_data(
     manu_data: dict[int, bytes],
     device_name: str | None = None


### PR DESCRIPTION
## What

Lets device discovery identify a device from its **name** when the advertisement has no manufacturer data, instead of silently rejecting it.

## Why

`_parse_discovery` required manufacturer data (`parse_manufacturer_data` returns `None` when it's absent), aborting the flow as `not_supported`. Two real devices hit this and could not be added:

- **LEDnetWF rings under passive scanning** (e.g. DA81 `LEDnetWF02001D0CDA81`): the manu data with the product ID lives in a scan response that passive scanning never captures, so HA only has the name packet.
- **Service-data-only IOTBT devices** (e.g. `IOTBT812`, service UUID `0x5A00`, empty manufacturer data).

In both, the **name is in the primary advert** and carries the product identity, so rejecting was wrong.

## How

- `protocol.product_id_from_name`: derives the product ID from the name.
  - `IOTBT*` → `0x00` (same rule as the manu-data path).
  - LEDnetWF long form → 4 hex chars at offset `10:14` (matches manu-data bytes 8-9), e.g. `LEDnetWF02001D0CDA81` → `0x1D`.
- `config_flow._parse_discovery`: when manu data is absent, fall back to the name. A name-derived LEDnetWF id is only trusted if it maps to a **known** product; otherwise `product_id` stays `None` and capabilities are probed. When manu data is present, nothing changes.

The name yields the **same** `product_id` that manu data would have, so downstream setup is identical to a normally-discovered device.

## Testing

Verified `product_id_from_name` against live captures:
- `LEDnetWF02001D0CDA81` / `...DC48` → `0x1D` (FillLight)
- `LEDnetWF0200A362D9AB` → `0xA3` (Symphony)
- `IOTBT812` / `IOTBT6BA` → `0x00` (IOTBT)
- short/unknown names → `None` (probe fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)