### PR TITLE
Presence-based availability, ring LED read-back, IOTBT protocol dropdown

### DIFF
--- a/custom_components/lednetwf_ble/config_flow.py
+++ b/custom_components/lednetwf_ble/config_flow.py
@@ -16,7 +16,14 @@ from homeassistant.const import CONF_MAC, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.device_registry import format_mac
-from homeassistant.helpers.selector import NumberSelector, NumberSelectorConfig, NumberSelectorMode
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from bleak_retry_connector import BleakNotFoundError
 
@@ -282,7 +289,11 @@ class LEDNetWFConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "Device capabilities after flash test: has_ic_config=%s, has_color_order=%s, effect_type=%s",
                     caps.get("has_ic_config"), caps.get("has_color_order"), caps.get("effect_type")
                 )
-                if caps.get("has_ic_config"):
+                if (caps.get("has_ic_config")
+                        or caps.get("effect_type") == EffectType.ADDRESSABLE_0x53):
+                    # Ring / FillLight devices answer the same 0x63 query (parsed in
+                    # the ring-specific branch); if they don't, this times out and we
+                    # fall back to defaults, so it is safe to attempt.
                     led_settings = await device.query_led_settings_and_wait(timeout=3.0)
                     if led_settings:
                         _LOGGER.info(
@@ -685,7 +696,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             current_protocol = options.get(CONF_IOTBT_PROTOCOL, IOTBT_PROTOCOL_AUTO)
             schema_dict[
                 vol.Optional(CONF_IOTBT_PROTOCOL, default=current_protocol)
-            ] = vol.In(list(IOTBT_PROTOCOL_CHOICES))
+            ] = SelectSelector(
+                SelectSelectorConfig(
+                    options=list(IOTBT_PROTOCOL_CHOICES),
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            )
 
         # Calculate total LEDs for display in description
         placeholders = {}

--- a/custom_components/lednetwf_ble/device.py
+++ b/custom_components/lednetwf_ble/device.py
@@ -196,6 +196,26 @@ class LEDNetWFDevice:
         return self._is_on
 
     @property
+    def available(self) -> bool:
+        """Return True if the entity should be considered available.
+
+        Once we have real state (is_on known) we're clearly available. Otherwise
+        fall back to Bluetooth presence: some devices (e.g. passively-scanned
+        LEDnetWF strips/rings) only advertise their name and never push state, so
+        is_on can stay None until the first connection. Treating a present,
+        connectable device as available lets the user command it, which establishes
+        a connection and populates state.
+        """
+        if self._is_on is not None:
+            return True
+        try:
+            return bool(
+                bluetooth.async_address_present(self._hass, self._address, connectable=True)
+            )
+        except Exception:  # pragma: no cover - defensive, never block availability logic
+            return False
+
+    @property
     def brightness(self) -> int:
         """Return brightness (0-255)."""
         return self._brightness
@@ -1183,7 +1203,11 @@ class LEDNetWFDevice:
 
     def _parse_led_settings_response(self, data: bytes) -> None:
         """Parse 0x63 LED settings response."""
-        result = protocol.parse_led_settings_response(data)
+        # Ring / FillLight (ADDRESSABLE_0x53) devices use a different 0x63 layout.
+        if self.effect_type == EffectType.ADDRESSABLE_0x53:
+            result = protocol.parse_ring_led_settings_response(data)
+        else:
+            result = protocol.parse_led_settings_response(data)
         if not result:
             return
 

--- a/custom_components/lednetwf_ble/light.py
+++ b/custom_components/lednetwf_ble/light.py
@@ -120,7 +120,7 @@ class LEDNetWFLight(LightEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._device.is_on is not None
+        return self._device.available
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/lednetwf_ble/manifest.json
+++ b/custom_components/lednetwf_ble/manifest.json
@@ -27,5 +27,5 @@
         "bleak-retry-connector>=1.17.1",
         "bleak>=0.17.0"
     ],
-    "version": "2.0.1-beta7"
+    "version": "2.0.1-beta8"
 }

--- a/custom_components/lednetwf_ble/number.py
+++ b/custom_components/lednetwf_ble/number.py
@@ -74,7 +74,7 @@ class LEDNetWFEffectSpeed(NumberEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._device.is_on is not None
+        return self._device.available
 
     @property
     def native_value(self) -> float:

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -1565,6 +1565,29 @@ def parse_state_response(data: bytes) -> dict | None:
     }
 
 
+def parse_ring_led_settings_response(data: bytes) -> dict | None:
+    """
+    Parse the 0x63 LED settings response for ADDRESSABLE_0x53 ring / FillLight devices.
+
+    Source: v1 integration (RING_LIGHT_MODEL branch). The ring response packs the
+    values differently to the Symphony format below:
+        Byte 0: header (0x63)
+        Byte 2: led_count (single byte; these devices have one segment)
+        Byte 3: chip_type (RingLedType numbering)
+        Byte 4: color_order (ColorOrder numbering)
+
+    Returns dict with led_count / ic_type / color_order / segments, or None if invalid.
+    """
+    if len(data) < 5 or data[0] != 0x63:
+        return None
+    return {
+        "led_count": data[2] & 0xFF,
+        "ic_type": data[3] & 0xFF,
+        "color_order": data[4] & 0xFF,
+        "segments": 1,
+    }
+
+
 def parse_led_settings_response(data: bytes) -> dict | None:
     """
     Parse LED settings response (0x63 format - IC Settings).


### PR DESCRIPTION
## What
- **Availability fix (presence-based):** an entity is available when it has state **or** is present/connectable over Bluetooth, not only once state has been pushed.
- **Ring LED-count read-back:** `ADDRESSABLE_0x53` ring/FillLight devices now report their actual LED count into the Configure dialog instead of showing the default.
- **IOTBT protocol selector** rendered as a **dropdown** instead of radio buttons.

## Why
Devices that advertise name-only under passive scanning (LEDnetWF rings/strips) never push state, so `available = is_on is not None` left them stuck "unavailable" and uncontrollable after adding (e.g. #86, and the DA81 ring). Presence-based availability lets the user command them, which connects on demand and fetches state, and removes the need to force ESPHome proxies into active scanning.

## How
- `device.available` = `is_on is not None or bluetooth.async_address_present(connectable=True)`; `light`/`number` defer to it. Background-colour entity keeps its stricter rule.
- `parse_ring_led_settings_response` for the ring 0x63 layout (count=b2, chip=b3, order=b4); queried at add time (times out → default, so safe).
- IOTBT protocol field uses `SelectSelector(mode=DROPDOWN)`.

## Deferred (with reasons)
- **ble_version 8 framing**: device works on our v0 framing; switching risks regressing it for no proven gain.
- **~50 Telink effects**: capture gives IDs but not names.
- **IC-type config for Telink IOTBT**: depends on the beta7 Telink routing being confirmed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)