### PR TITLE
IOTBT segment LED count: send 0xE0 0x14 commit after 0xE1 0x08 preview

### DIFF
--- a/SNIFFING_BLE_TRAFFIC.md
+++ b/SNIFFING_BLE_TRAFFIC.md
@@ -173,13 +173,54 @@ This method uses Android's built-in Bluetooth HCI (Host Controller Interface) lo
 
 The log file location varies by Android version and manufacturer:
 
-**Common locations**:
+On modern Android, the snoop log lives at `/data/misc/bluetooth/logs/btsnoop_hci.log`, which is **not readable without root** via a normal `adb pull` or a file manager. The bugreport method below works around this without root, so try it first.
+
+**Common locations** (older Android / some manufacturers, for the manual methods):
 - `/sdcard/btsnoop_hci.log` (some Samsung, older Android)
 - `/sdcard/Android/data/btsnoop_hci.log`
-- `/data/misc/bluetooth/logs/btsnoop_hci.log` (requires root)
+- `/data/misc/bluetooth/logs/btsnoop_hci.log` (root-only via normal tools)
 - `/data/misc/bluedroid/btsnoop_hci.log` (older Android)
 
-**Method A: Using ADB (Recommended)**
+**Method A: ADB Bugreport (Recommended - no root, no path guessing)**
+
+`adb bugreport` invokes Android's `dumpstate` service, which runs as a privileged
+system process. That lets it read the root-only snoop log and bundle it into a zip
+for you, so you don't need root and don't need to know where the log lives. This is
+the most reliable method on stock unrooted devices, and the path is the same
+regardless of manufacturer.
+
+> **Important**: `bugreport` only *retrieves* what was already logged - it does not
+> start logging. You must have **Bluetooth HCI snoop log** enabled in Developer
+> Options *before* you connect the app and perform your actions (see Step 3).
+
+1. **Connect your device** to the computer via USB
+2. **Enable USB Debugging** in Developer Options and **authorize the computer** (popup on phone)
+3. **Do your capture first** (Step 3 above) with HCI snoop logging already enabled
+4. **Generate and pull the bugreport** immediately afterwards (the snoop log is a
+   fixed-size rotating buffer, so don't wait):
+   ```bash
+   adb bugreport capture.zip
+   ```
+   This can take 1-3 minutes and produces a zip of tens of MB - that's normal.
+5. **Extract the snoop log** from the zip. It is found at:
+   ```
+   FS/data/misc/bluetooth/logs/btsnoop_hci.log
+   ```
+   (there may be rotated siblings such as `btsnoop_hci.log.last`). For example:
+   ```bash
+   unzip -o capture.zip "FS/data/misc/bluetooth/logs/btsnoop_hci.log*"
+   ```
+   Open `btsnoop_hci.log` directly in Wireshark (Step 5 below).
+6. **Disable HCI snoop** after capturing (it can fill storage)
+
+> **Note**: The main `.txt` file inside the bugreport also contains a small embedded,
+> compressed "btsnooz" snippet. Ignore that - you want the full `btsnoop_hci.log`
+> file under `FS/data/...`, which is the complete capture.
+
+If `adb bugreport` is restricted on your device (rare, mostly heavily customised
+ROMs), fall back to one of the methods below.
+
+**Method B: Using ADB Pull (older Android, or logs on /sdcard)**
 
 1. **Connect your device** to computer via USB
 2. **Enable USB Debugging** in Developer Options
@@ -189,21 +230,21 @@ The log file location varies by Android version and manufacturer:
    # Try common locations
    adb pull /sdcard/btsnoop_hci.log btsnoop_hci.log
    adb pull /sdcard/Android/data/btsnoop_hci.log btsnoop_hci.log
-   
+
    # If you have root access
    adb shell su -c "cp /data/misc/bluetooth/logs/btsnoop_hci.log /sdcard/"
    adb pull /sdcard/btsnoop_hci.log btsnoop_hci.log
    ```
 5. **Disable HCI snoop** after capturing (it can fill storage)
 
-**Method B: Using File Manager App**
+**Method C: Using File Manager App**
 
 1. Install a file manager app (e.g., [Solid Explorer](https://play.google.com/store/apps/details?id=pl.solidexplorer2))
 2. Navigate to the log location
 3. Copy the file to a location you can access
 4. Transfer to your computer (USB, cloud, email, etc.)
 
-**Method C: Android Studio**
+**Method D: Android Studio**
 
 1. Open **Android Studio**
 2. Go to **View** → **Tool Windows** → **Device File Explorer**
@@ -226,7 +267,8 @@ The log file location varies by Android version and manufacturer:
 
 ### Troubleshooting HCI Snoop
 
-**Problem**: Can't find the log file
+**Problem**: Can't find the log file (or `adb pull` gives "Permission denied")
+- **Solution**: Use the **ADB Bugreport** method (Method A) - it reads the root-only log for you, so you don't need to locate it or have root
 - **Solution**: Try all common locations listed above
 - **Solution**: Check if HCI logging is actually enabled
 - **Solution**: Some devices save to different locations - check XDA forums for your device model

--- a/custom_components/lednetwf_ble/device.py
+++ b/custom_components/lednetwf_ble/device.py
@@ -1852,10 +1852,23 @@ class LEDNetWFDevice:
         those). Other devices use the original format.
         """
         if self.is_iotbt_segment:
-            # IOTBT segment lamps: 0xE1 0x08 length command (count + segments only)
-            packet = protocol.build_iotbt_segment_led_settings_command(
-                led_count, segments
-            )
+            # IOTBT segment lamps: the 0xE1 0x08 command is only a live preview; the
+            # device persists the value on a separate 0xE0 0x14 "commit" (the app's
+            # Save). Send preview then commit. The device may restart to apply the
+            # new length, dropping the BLE connection briefly - that's expected and
+            # the integration will reconnect on next use.
+            # NOTE: the 0xE0 0x14 commit is a hypothesis from issue #83 pending a
+            # clean capture; if it proves wrong, revert to sending only the preview.
+            preview = protocol.build_iotbt_segment_led_settings_command(led_count, segments)
+            commit = protocol.build_iotbt_segment_led_commit_command(led_count, segments)
+            ok = await self._send_command(preview)
+            if ok:
+                await asyncio.sleep(0.3)
+                ok = await self._send_command(commit)
+            if ok:
+                self._led_count = led_count
+                self._segments = segments
+            return ok
         elif self.effect_type == EffectType.ADDRESSABLE_0x53:
             # Ring / FillLight devices: short 0x62 ring command (count + chip + order,
             # single segment). chip_type uses the ring-specific RingLedType numbering.

--- a/custom_components/lednetwf_ble/manifest.json
+++ b/custom_components/lednetwf_ble/manifest.json
@@ -27,5 +27,5 @@
         "bleak-retry-connector>=1.17.1",
         "bleak>=0.17.0"
     ],
-    "version": "2.0.1-beta8"
+    "version": "2.0.1-beta9"
 }

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -616,6 +616,32 @@ def build_iotbt_segment_led_settings_command(
     return wrap_command(raw_cmd, cmd_family=0x0B)
 
 
+def build_iotbt_segment_led_commit_command(
+    leds_per_segment: int, segment_count: int
+) -> bytearray:
+    """
+    Build the IOTBT segment LED-length COMMIT command (0xE0 0x14 format).
+
+    HYPOTHESIS (GitHub issue #83, samoswall): in the app's capture the 0xE1 0x08
+    command is sent on every keystroke as a *live preview*, and a single 0xE0 0x14
+    command is sent when the user taps *Save*, carrying the final values:
+        E0 14 01 00 00 [leds_per_segment] [segment_count] 00
+    Sending only the 0xE1 0x08 preview (as we did) did not persist the value, hence
+    "the value doesn't change" and the device freezing. This commit is the missing
+    half. UNCONFIRMED until a clean capture of the Save action verifies it.
+    """
+    leds_per_segment = max(1, min(255, leds_per_segment))
+    segment_count = max(1, min(255, segment_count))
+
+    raw_cmd = bytearray([
+        0xE0, 0x14, 0x01, 0x00, 0x00,
+        leds_per_segment & 0xFF,
+        segment_count & 0xFF,
+        0x00,
+    ])
+    return wrap_command(raw_cmd, cmd_family=0x0B)
+
+
 def build_ring_led_settings_command(
     led_count: int, chip_type: int, color_order: int
 ) -> bytearray:


### PR DESCRIPTION
Fixes #83 LED-count-not-saving (hypothesis). The app sends 0xE1 0x08 as a live preview per keystroke, then a single 0xE0 0x14 commit on Save; we only sent the preview, so the value never persisted. Adds the commit command (byte-exact to the capture) and sends preview→commit for segment devices, tolerating the device restart. Unconfirmed pending a clean capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)