### PR TITLE
Confirm IOTBT segment LED-count commit; record read-back format

### DIFF
--- a/ai_instructions/iotbt_variant_findings.md
+++ b/ai_instructions/iotbt_variant_findings.md
@@ -273,3 +273,25 @@ remain correct for the payloads.
    ALL writes (incl. power). This is NOT IOTBT-specific — it affects any LEDnetWF device whose
    firmware reaches ble_version 8. **wrap_command should branch on advertised ble_version
    (>=8 → v1 framing).** Likely higher priority than the Telink/segment split.
+
+## IOTBT segment "LEDs per segment" - confirmed fix + read-back format (issue #83, 2026-06-28)
+
+samoswall confirmed setting LEDs-per-segment works in 2.0.1-beta9, and provided a clean HCI
+capture (lednum2.zip) of the Save action.
+
+**Set sequence (app -> device), confirmed byte-for-byte:**
+```
+E1 08 FF 00 <leds> 00 64 3C 64 78 64 00 00 <segs>   <- live PREVIEW, one per keystroke
+E0 14 01 00 00 <leds> <segs> 00                     <- COMMIT, sent on Save (e.g. ...3C 01 00 = 60/1)
+```
+We now send preview then commit (build_iotbt_segment_led_settings_command +
+build_iotbt_segment_led_commit_command). The device may restart to apply (brief disconnect).
+
+**Read-back format (device -> app, 0xEA 0x81 state response payload):**
+- `payload[16]`   = segment count
+- `payload[17:19]` = LEDs per segment, big-endian
+Verified by the 57 -> 60 change in the capture (`...01 00 39...` -> `...01 00 3C...`).
+
+**Decision (Will, 2026):** NOT implementing read-back or sensors for this. The LED count
+stays a write-only config item, as it is now; the read-back data isn't worth surfacing. The
+format is recorded here only in case that changes.

--- a/custom_components/lednetwf_ble/device.py
+++ b/custom_components/lednetwf_ble/device.py
@@ -1856,9 +1856,8 @@ class LEDNetWFDevice:
             # device persists the value on a separate 0xE0 0x14 "commit" (the app's
             # Save). Send preview then commit. The device may restart to apply the
             # new length, dropping the BLE connection briefly - that's expected and
-            # the integration will reconnect on next use.
-            # NOTE: the 0xE0 0x14 commit is a hypothesis from issue #83 pending a
-            # clean capture; if it proves wrong, revert to sending only the preview.
+            # the integration will reconnect on next use. Confirmed against the
+            # issue #83 capture and working on the device.
             preview = protocol.build_iotbt_segment_led_settings_command(led_count, segments)
             commit = protocol.build_iotbt_segment_led_commit_command(led_count, segments)
             ok = await self._send_command(preview)

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -622,13 +622,14 @@ def build_iotbt_segment_led_commit_command(
     """
     Build the IOTBT segment LED-length COMMIT command (0xE0 0x14 format).
 
-    HYPOTHESIS (GitHub issue #83, samoswall): in the app's capture the 0xE1 0x08
-    command is sent on every keystroke as a *live preview*, and a single 0xE0 0x14
-    command is sent when the user taps *Save*, carrying the final values:
+    Source: GitHub issue #83 (samoswall) HCI capture. The app sends 0xE1 0x08 on
+    every keystroke as a *live preview*, then a single 0xE0 0x14 command when the
+    user taps *Save*, carrying the final values:
         E0 14 01 00 00 [leds_per_segment] [segment_count] 00
-    Sending only the 0xE1 0x08 preview (as we did) did not persist the value, hence
-    "the value doesn't change" and the device freezing. This commit is the missing
-    half. UNCONFIRMED until a clean capture of the Save action verifies it.
+    Sending only the 0xE1 0x08 preview did not persist the value (the value didn't
+    change and the device froze); this commit is the missing half. Confirmed
+    byte-for-byte against the capture (E0 14 01 00 00 3C 01 00 for 60 LEDs / 1
+    segment) and confirmed working on the device by the reporter.
     """
     leds_per_segment = max(1, min(255, leds_per_segment))
     segment_count = max(1, min(255, segment_count))


### PR DESCRIPTION
samoswall confirmed the beta9 LED-count fix works, with a clean HCI capture verifying the preview+commit bytes. Drops the hypothesis caveats from code comments and records the confirmed sequence + read-back format in the findings doc (with the decision not to add read-back/sensors). Comment/doc only, no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)