### PR TITLE
IOTBT segment: read back LEDs-per-segment from state response

### DIFF
--- a/custom_components/lednetwf_ble/config_flow.py
+++ b/custom_components/lednetwf_ble/config_flow.py
@@ -603,8 +603,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if is_iotbt_segment:
             # IOTBT segment lamps only configure LEDs-per-segment and segment count
             # (LED type / colour order are not exposed by these devices).
-            current_led_count = options.get(CONF_LED_COUNT, DEFAULT_LED_COUNT)
-            current_segments = options.get(CONF_SEGMENTS, DEFAULT_SEGMENTS)
+            # Read the device's actual config from its 0xEA 0x81 state response so the
+            # form shows real values rather than the stored/default; the parser fills
+            # device.led_count / device.segments. Falls back if the device is silent.
+            try:
+                await device.query_state_and_wait(timeout=3.0)
+            except Exception:  # noqa: BLE001 - never block the options form on a BLE read
+                _LOGGER.debug("Could not read live LED config for %s", device.name)
+            current_led_count = (
+                device.led_count or options.get(CONF_LED_COUNT, DEFAULT_LED_COUNT)
+            )
+            current_segments = (
+                device.segments or options.get(CONF_SEGMENTS, DEFAULT_SEGMENTS)
+            )
 
             schema_dict.update({
                 vol.Optional(CONF_LED_COUNT, default=current_led_count): NumberSelector(

--- a/custom_components/lednetwf_ble/device.py
+++ b/custom_components/lednetwf_ble/device.py
@@ -848,6 +848,19 @@ class LEDNetWFDevice:
 
         self._is_on = is_on
 
+        # Segment IOTBT devices report their LED configuration in this response:
+        #   payload[16]    = segment count
+        #   payload[17:19] = LEDs per segment (big-endian)
+        # Source: issue #83 (samoswall) capture, verified by the 57->60 change.
+        # Gated on segment: on Telink IOTBT these bytes mean something else.
+        if self.is_iotbt_segment and len(data) >= 19:
+            self._segments = data[16] & 0xFF
+            self._led_count = (data[17] << 8) | data[18]
+            _LOGGER.debug(
+                "DeviceState2 LED config: segments=%d, leds_per_segment=%d",
+                self._segments, self._led_count,
+            )
+
         # NOTE: DeviceState2 format (IOTBT devices) does NOT use standard RGB encoding
         # in bytes 7-9. IOTBT devices use hue-based color commands (0xE2) not RGB.
         # The values in bytes 7-9 are unreliable for color display.

--- a/custom_components/lednetwf_ble/manifest.json
+++ b/custom_components/lednetwf_ble/manifest.json
@@ -27,5 +27,5 @@
         "bleak-retry-connector>=1.17.1",
         "bleak>=0.17.0"
     ],
-    "version": "2.0.1-beta9"
+    "version": "2.0.1-beta10"
 }


### PR DESCRIPTION
Reads the segment lamp's actual LED config from the 0xEA 0x81 state response (payload[16]=segments, [17:19]=LEDs/segment BE; confirmed in #83). The DeviceState2 parser now extracts it for segment devices, and the Configure dialog reads it live so it shows the device's real count instead of the default. Falls back to stored/default if silent. No sensors, just the existing config field pre-filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)