### PR TITLE
IOTBT segment: send 0xE1 commands with cmd_family 0x0B (#97)

### DIFF
--- a/ai_instructions/DISCOVERIES.md
+++ b/ai_instructions/DISCOVERIES.md
@@ -163,12 +163,14 @@ IOTBT builders, not taken from a capture.
 **Reality**: In both app captures (issue #83 IOTBT6BA, issue #97 IOTBT4B0) the
 app sends ALL state-changing commands with cmd_family **0x0B** (power 0x3B,
 time sync 0x10, effects 0xE1 0x01) and reserves **0x0A for queries** (the
-0xEA 0x81 state read). On the IOTBT4B0 (issue #97, Vibe Pixie String Lights),
-effects sent with 0x0A did nothing at all, while colour (also 0x0A at the
-time) happened to work - so tolerance of the wrong family byte varies by
-firmware and opcode. The issue #97 capture confirmed our 0xE1 0x01 payloads
-were already byte-identical to the app's (scenes 2-10 verified); the family
-byte was the only difference on the wire.
+0xEA 0x81 state read). Tolerance of the wrong family byte varies by firmware
+and opcode: the IOTBT6BA (#83) accepted 0x0A for both colour AND effects
+(confirmed working), while the IOTBT4B0 (#97) accepted 0x0A for colour but
+ignored 0x0A effects entirely. The issue #97 capture confirmed our 0xE1 0x01
+payloads were already byte-identical to the app's (scenes 2-10 verified); the
+family byte was the only difference on the wire. Switching to 0x0B is safe for
+devices that worked on 0x0A, because 0x0B is what the official app sends to
+these exact devices (proven by both captures).
 
 **Rule of thumb**: when adding a command builder, take the cmd_family byte
 from the capture too, not just the payload. 0x0A = query, 0x0B = command.

--- a/ai_instructions/DISCOVERIES.md
+++ b/ai_instructions/DISCOVERIES.md
@@ -151,6 +151,33 @@ for device in ble_data:
 
 ---
 
+### IOTBT Segment Commands - Wrong Transport cmd_family (0x0A vs 0x0B)
+
+**Date**: 18 July 2026
+
+**Error**: `build_iotbt_segment_effect_command` (0xE1 0x01) and
+`build_iotbt_segment_color_command` (0xE1 0x03) wrapped their payloads with
+`cmd_family=0x0A` ("expects response"). The 0x0A was carried over from earlier
+IOTBT builders, not taken from a capture.
+
+**Reality**: In both app captures (issue #83 IOTBT6BA, issue #97 IOTBT4B0) the
+app sends ALL state-changing commands with cmd_family **0x0B** (power 0x3B,
+time sync 0x10, effects 0xE1 0x01) and reserves **0x0A for queries** (the
+0xEA 0x81 state read). On the IOTBT4B0 (issue #97, Vibe Pixie String Lights),
+effects sent with 0x0A did nothing at all, while colour (also 0x0A at the
+time) happened to work - so tolerance of the wrong family byte varies by
+firmware and opcode. The issue #97 capture confirmed our 0xE1 0x01 payloads
+were already byte-identical to the app's (scenes 2-10 verified); the family
+byte was the only difference on the wire.
+
+**Rule of thumb**: when adding a command builder, take the cmd_family byte
+from the capture too, not just the payload. 0x0A = query, 0x0B = command.
+
+**Files fixed**:
+- `custom_components/lednetwf_ble/protocol.py` (both segment builders now 0x0B)
+
+---
+
 ## Products Not in Current Database
 
 These product IDs appear in documentation but NOT in the current app database:

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -472,8 +472,10 @@ def build_iotbt_segment_color_command(
             combined_bright & 0xFF   # Brightness (0-100)
         ])
 
-    # No checksum for this command format
-    return wrap_command(raw_cmd, cmd_family=0x0a)
+    # No checksum for this command format.
+    # cmd_family 0x0B matches the app capture (issue #83 findings: `0B E1 03 ...`);
+    # the app uses 0x0A only for queries.
+    return wrap_command(raw_cmd, cmd_family=0x0B)
 
     
 # Per-scene templates for the IOTBT segment effect list (0xE1 0x01 command).
@@ -583,7 +585,10 @@ def build_iotbt_segment_effect_command(effect_id: int, speed: int = 50, brightne
     for b1, b2, b3 in palette:
         payload.extend([0xA1, b1 & 0xFF, b2 & 0xFF, b3 & 0xFF])
 
-    return wrap_command(payload, cmd_family=0x0A)
+    # cmd_family 0x0B (no response) matches the app captures (issues #83, #97).
+    # The app reserves 0x0A for queries (e.g. the 0xEA 0x81 state read); on at
+    # least the IOTBT4B0 (issue #97) an 0x0A-wrapped 0xE1 0x01 has no effect.
+    return wrap_command(payload, cmd_family=0x0B)
 
 
 def build_iotbt_segment_led_settings_command(


### PR DESCRIPTION
Fixes the likely cause of #97 (IOTBT4B0: RGB works, effects do not).

The reporter's `writer.bytes` capture from the Zengge app contained nine effect commands. Decoding them shows our `0xE1 0x01` payloads are already **byte-identical** to the app's (scenes 2-10 of the segment scene table all round-trip exactly, including per-scene mode bytes and palettes). The only difference on the wire is the transport `cmdId`: we wrap segment effect and colour commands with `0x0A` (expects response), the app uses `0x0B`.

Across both captures we have (#83 IOTBT6BA, #97 IOTBT4B0), the app consistently uses:
- `0x0B` for every state-changing command (power `0x3B`, time sync `0x10`, effects `0xE1 0x01`, colour `0xE1 0x03`)
- `0x0A` only for queries (the `0xEA 0x81` state read)

That matches our own `wrap_command` docstring ("0x0a for queries, 0x0b for commands"). The `0x0A` in the segment builders was carried over from earlier IOTBT code, not taken from a capture.

**Blast radius / regression risk:**
- Only devices routed to the IOTBT **segment** variant are affected. All other effect paths (Telink IOTBT `0xE0 0x02`, SIMPLE, Symphony `0x38`, legacy `0x61`, `0x53` ring) are untouched.
- The IOTBT6BA (#83) has **confirmed-working effects and colour on the old `0x0A` wrapping**, so this change does alter a working configuration there. However, both segment captures show the official app sending these exact commands with `0x0B` to both devices, so `0x0B` is the wire format these lamps handle from the vendor app every day. The tolerance for `0x0A` is what varies by firmware (the IOTBT4B0 accepts it for colour but apparently not for effects).
- Would be good to get a regression test from @samoswall (IOTBT6BA) as well as a fix confirmation from the #97 reporter (IOTBT4B0) before merging.

Changes:
- `build_iotbt_segment_effect_command` (`0xE1 0x01`): wrap with `0x0B`
- `build_iotbt_segment_color_command` (`0xE1 0x03`): wrap with `0x0B` (per the #83 capture `0B E1 03 ...`)
- DISCOVERIES.md entry recording the correction and the rule of thumb (take the cmd_family from the capture too, not just the payload)

Verified: all nine captured effect commands and both captured power commands now match our builders byte-for-byte (ignoring the sequence counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
