### PR TITLE
Fix state feedback corrupting control for Ctrl_Mini_RGB_Mic (#99)

### DIFF
--- a/ai_instructions/DISCOVERIES.md
+++ b/ai_instructions/DISCOVERIES.md
@@ -4,6 +4,70 @@ This document tracks significant findings and corrections made during the revers
 
 ## Documentation Errors Found and Fixed
 
+### Effect ID 37 collides with the 0x25 "effect mode" marker
+
+**Date**: 1 August 2026 (issue #99)
+
+**Problem**: SIMPLE devices report the running effect ID directly in the
+mode_type byte (37-56). The first effect in the list is ID 37, which is 0x25,
+the same value Symphony/Addressable devices use as the "effect mode" marker
+with the real ID in sub_mode.
+
+Both parsers assumed the Symphony meaning unconditionally:
+
+- `parse_state_response()` set `is_effect_mode = mode_type == 0x25` and then
+  took the effect ID from sub_mode. Effect 37 decoded as "effect id = whatever
+  is in sub_mode", and effects 38-56 were not recognised as effect mode at all.
+- `parse_manufacturer_data()` had an `elif mode_type == 0x25` branch that
+  shadowed the correct `elif 37 <= mode_type <= 56` branch below it, then
+  applied a +20 offset guess to sub_mode.
+
+Observed effect: a device running effect 37 was reported as effect 55 with the
+speed read out of an RGB byte.
+
+**Fix**: both parsers now take a `simple_effects` flag from the caller and
+check the 37-56 range first for those devices.
+
+**Note**: sub_mode is NOT reliably the speed on these devices. It is often an
+echo of the power state (0x23=ON, 0x24=OFF), so it is ignored when it holds
+those values. The full byte layout for SIMPLE effect state is still unconfirmed
+and needs a capture.
+
+---
+
+### Speed encode/decode were not inverses (drift on every round-trip)
+
+**Date**: 1 August 2026 (issue #99)
+
+**Problem**: two independent bugs made the effect speed drift every time state
+was read back and reused by the next effect command:
+
+1. Products 0x08 and 0x3C send effects with the inverted 1-31 speed encoding
+   (`scene_data_v2` declares speed min=1 max=31) but were missing from
+   `INVERTED_SPEED_PRODUCT_IDS`, so the reported value was read as a 0-100
+   percentage.
+2. The encoder `1 + int(30 * (1.0 - pct / 100))` truncates the wrong way for
+   some values because of float representation. At 80%, `30 * 0.19999999999999996`
+   is 5.999... which truncates to 5 instead of 6, so it disagreed with the
+   decoder even once the scale was right.
+
+**Fix**: added `convert_speed_to_inverted_31()` using integer arithmetic, used
+by every inverted-speed encoder, and rewrote the decoder to be its exact
+inverse. `decode(encode(pct))` is now a fixed point for all values 1-100.
+
+---
+
+### Product 0x3C (60) was missing from PRODUCT_CAPABILITIES
+
+**Date**: 1 August 2026 (issue #99)
+
+**Problem**: 0x3C is the same Ctrl_Mini_RGB_Mic as 0x08 (identical function
+list in `ble_devices.json`) but had no entry, so it fell through to the
+unknown-product fallback which assumes `EffectType.SYMPHONY` - an entirely
+different command family.
+
+---
+
 ### Product 0x08 (8) - Ctrl_Mini_RGB_Mic
 
 **Date**: 7 December 2025

--- a/ai_instructions/DISCOVERIES.md
+++ b/ai_instructions/DISCOVERIES.md
@@ -30,6 +30,33 @@ check the 37-56 range first for those devices.
 
 ---
 
+### Never pair 0x3B brightness with a colour command (write-without-response)
+
+**Date**: 2 August 2026 (issue #99)
+
+Commands are sent write-without-response (`_send_command` defaults to
+`with_response=False`), so two writes issued back to back land about 1ms
+apart. If a `0x3B 0x01` brightness command follows a `0x31` colour command
+that closely, the device has not yet committed the colour, and `0x3B`
+rescales the colour it *still holds* - cancelling the change.
+
+Observed on a green light asked repeatedly for pure blue: the blue channel
+crept 0 -> 16 -> 28 over three attempts and never arrived, because each `0x31`
+only had ~1ms to act before the `0x3B` reasserted green.
+
+`bright_value_v2` itself is fine and does exactly what it says. Verified in
+the same log: 1% on a green light gives `(0,3,0)`, 100% restores `(0,255,0)`.
+
+**Rules:**
+
+- Brightness-only change: use `0x3B 0x01`. One command, no colour re-send, and
+  it does not re-trigger a running effect.
+- Colour change: put the brightness in the scaled RGB of the `0x31` and send
+  nothing else. The device stores the scaled RGB anyway, which is why
+  deriving brightness back out of the reported RGB via HSV is correct.
+
+---
+
 ### SIMPLE state layout confirmed by capture (product 0x08)
 
 **Date**: 2 August 2026 (issue #99)

--- a/ai_instructions/DISCOVERIES.md
+++ b/ai_instructions/DISCOVERIES.md
@@ -28,10 +28,51 @@ speed read out of an RGB byte.
 **Fix**: both parsers now take a `simple_effects` flag from the caller and
 check the 37-56 range first for those devices.
 
-**Note**: sub_mode is NOT reliably the speed on these devices. It is often an
-echo of the power state (0x23=ON, 0x24=OFF), so it is ignored when it holds
-those values. The full byte layout for SIMPLE effect state is still unconfirmed
-and needs a capture.
+---
+
+### SIMPLE state layout confirmed by capture (product 0x08)
+
+**Date**: 2 August 2026 (issue #99)
+
+An nRF Connect capture of the 0x81 notifications, cross-checked against the
+commands the integration sent, pins the layout down. Every checksum verified.
+
+Effect running (`mode_type` = effect ID, 37-56):
+
+| Byte | Meaning |
+|------|---------|
+| 3 | Effect ID (37-56). NOT a 0x25 mode marker |
+| 4 | Sub-mode: echo of the power state (0x23=ON, 0x24=OFF) |
+| 5 | **Effect speed, inverted 1-31** |
+| 6-8 | The colour the effect is showing *right now*, changes constantly |
+
+Solid colour:
+
+| Byte | Meaning |
+|------|---------|
+| 3 | 0x61 |
+| 4 | Echo of the power state (0x23/0x24), NOT a colour-mode marker |
+| 5 | Effect speed, retained from the last effect |
+| 6-8 | The solid RGB colour |
+
+Evidence for byte 5 being the speed: sent `38 25 10 1E` (speed byte 0x10),
+response `value1` = 0x10. Sent `38 25 01 01`, response `value1` = 0x01. Sent
+`38 25 1F 01`, response `value1` = 0x1F. Three for three.
+
+**Brightness is not reported at all while an effect is running.** The old docs
+claimed byte 6 was the brightness in effect mode, which is wrong for this
+family - byte 6 is the red channel of the live effect colour.
+
+The advertisement state block mirrors this from byte 14 onwards, so advert
+byte 17 is the speed, not the brightness as previously assumed:
+
+```
+advert[14] = power     <-> response[2]
+advert[15] = mode_type <-> response[3]
+advert[16] = sub_mode  <-> response[4]
+advert[17] = speed     <-> response[5]
+advert[18:21] = rgb    <-> response[6:9]
+```
 
 ---
 

--- a/ai_instructions/DISCOVERIES.md
+++ b/ai_instructions/DISCOVERIES.md
@@ -101,11 +101,26 @@ corrupting the brightness. At a point where the device's brightness was 100
 (set via `3b 01 ... 64`) and its speed was 31 (set via `38 25 1F 01`), advert
 byte 17 read 31. Directly discriminating, not just positional alignment.
 
-**Brightness being absent from the effect-mode response is an argument from
-absence**, so treat it as weaker than the above. It rests on the brightness
-value appearing nowhere in the response in either discriminating case (no
-0x1E in the first, no 0x01 in the third), plus the two `0x3B` brightness
-commands producing no state notification at all.
+**Brightness is confirmed absent from the effect-mode state.** A later
+controlled test settled this: with an effect running and everything else left
+alone, brightness was changed to 15%, and the advertisement state block was
+byte-for-byte identical before and after.
+
+```
+before 15%   23 38 23 10 FF 00 00 00 03 00 F0
+after  15%   23 38 23 10 FF 00 00 00 03 00 F0   <- identical
+later        23 38 23 10 FF 00 FF 00 03 00 F0   <- only the live RGB moved
+```
+
+Consequence: **brightness changed by any other controller (IR remote, the
+app) cannot be detected while an effect is running.** The device does not
+report it. This is a protocol limitation, not something to fix.
+
+Note also that the RGB reported in effect mode is the effect's nominal colour
+at full intensity, NOT scaled by brightness - the (255,0,0) above was
+captured while the light was at 15%. This is the opposite of solid-colour
+mode, where the reported RGB *is* brightness-scaled. Never derive brightness
+from the RGB in effect mode.
 
 **Brightness is not reported at all while an effect is running.** The old docs
 claimed byte 6 was the brightness in effect mode, which is wrong for this

--- a/ai_instructions/DISCOVERIES.md
+++ b/ai_instructions/DISCOVERIES.md
@@ -55,9 +55,30 @@ Solid colour:
 | 5 | Effect speed, retained from the last effect |
 | 6-8 | The solid RGB colour |
 
-Evidence for byte 5 being the speed: sent `38 25 10 1E` (speed byte 0x10),
-response `value1` = 0x10. Sent `38 25 01 01`, response `value1` = 0x01. Sent
-`38 25 1F 01`, response `value1` = 0x1F. Three for three.
+**Evidence for byte 5 being the speed.** The outbound command is
+`38{model}{speed}{bright}`, so a pair only tells us anything when speed and
+bright differ:
+
+| Sent | speed | bright | Response `value1` | Discriminates? |
+|------|-------|--------|-------------------|----------------|
+| `38 25 10 1E` | 16 | 30 | 16 | Yes - matches speed |
+| `38 25 01 01` | 1 | 1 | 1 | No - both fields are 1 |
+| `38 25 1F 01` | 31 | 1 | 31 | Yes - matches speed |
+
+Two discriminating observations, and they are complementary: the speed is the
+larger of the two fields in one and the smaller in the other, so the match is
+not an artefact of always picking the bigger byte.
+
+The advertisement byte is separately confirmed, and this is the one that was
+corrupting the brightness. At a point where the device's brightness was 100
+(set via `3b 01 ... 64`) and its speed was 31 (set via `38 25 1F 01`), advert
+byte 17 read 31. Directly discriminating, not just positional alignment.
+
+**Brightness being absent from the effect-mode response is an argument from
+absence**, so treat it as weaker than the above. It rests on the brightness
+value appearing nowhere in the response in either discriminating case (no
+0x1E in the first, no 0x01 in the third), plus the two `0x3B` brightness
+commands producing no state notification at all.
 
 **Brightness is not reported at all while an effect is running.** The old docs
 claimed byte 6 was the brightness in effect mode, which is wrong for this

--- a/custom_components/lednetwf_ble/commands.py
+++ b/custom_components/lednetwf_ble/commands.py
@@ -21,6 +21,7 @@ import re
 from typing import Any
 
 from .capabilities import CAPABILITIES, CommandTemplate, FunctionCapability
+from .const import convert_speed_to_inverted_31
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -263,7 +264,7 @@ def build_effect_command(
         }
     elif func == "scene_data_v2":
         # v2: inverted 1-31 + brightness
-        protocol_speed = 1 + int(30 * (1.0 - speed / 100.0))
+        protocol_speed = convert_speed_to_inverted_31(speed)
         params = {
             "model": effect_id,
             "speed": protocol_speed,
@@ -271,7 +272,7 @@ def build_effect_command(
         }
     else:
         # Legacy scene_data: inverted 1-31, no brightness
-        protocol_speed = 1 + int(30 * (1.0 - speed / 100.0))
+        protocol_speed = convert_speed_to_inverted_31(speed)
         params = {
             "model": effect_id,
             "speed": protocol_speed,

--- a/custom_components/lednetwf_ble/const.py
+++ b/custom_components/lednetwf_ble/const.py
@@ -492,6 +492,11 @@ IOTBT_SEGMENT_EFFECTS: Final = {
 # Note: Symphony devices (0xA1-0xA9) do NOT use inverted speed - they use 1=slow, 31=fast
 INVERTED_SPEED_PRODUCT_IDS: Final = {
     0x54, 0x55, 0x62, 0x5B,  # Strip controllers
+    # Ctrl_Mini_RGB_Mic. ble_devices.json declares scene_data_v2 with
+    # speed min=1 max=31 for both product IDs, and we send effects via the
+    # 0x38 command (38{model}{speed}{bright}) with the inverted 1-31 encoding.
+    # The state the device reports back is therefore also 1-31, not 0-100.
+    0x08, 0x3C,
 }
 
 # Product ID to capabilities mapping
@@ -513,8 +518,13 @@ PRODUCT_CAPABILITIES: Final = {
     # Product 0x08 uses rgb_mini_mic protocol (NOT Symphony)
     # Color: 0x31 format, State: wifibleLightStandardV1 (mode 0x61)
     # Source: Expert research confirmed this is NOT a Symphony device
-    8:   {"name": "Ctrl_Mini_RGB_Mic", "has_rgb": True, "has_ww": False, "has_cw": False, "effect_type": EffectType.SIMPLE, "has_builtin_mic": True, "mic_cmd_format": "simple", "uses_0x38_effects": True, "has_candle_mode": True},  # 0x08
+    8:   {"name": "Ctrl_Mini_RGB_Mic", "has_rgb": True, "has_ww": False, "has_cw": False, "effect_type": EffectType.SIMPLE, "has_builtin_mic": True, "mic_cmd_format": "simple", "uses_0x38_effects": True, "has_candle_mode": True, "has_brightness_cmd": True},  # 0x08
     16:  {"name": "ChristmasLight", "has_rgb": True, "has_ww": False, "has_cw": False, "effect_type": EffectType.SIMPLE},
+    # 0x3C is the same Ctrl_Mini_RGB_Mic device as 0x08 - identical function
+    # list in ble_devices.json (scene_data_v2, colour_data_v2, bright_value_v2,
+    # candle_data, set_mic_info). Without this entry it fell through to the
+    # unknown-product fallback, which assumes EffectType.SYMPHONY.
+    60:  {"name": "Ctrl_Mini_RGB_Mic", "has_rgb": True, "has_ww": False, "has_cw": False, "effect_type": EffectType.SIMPLE, "has_builtin_mic": True, "mic_cmd_format": "simple", "uses_0x38_effects": True, "has_candle_mode": True, "has_brightness_cmd": True},  # 0x3C
     51:  {"name": "Ctrl_Mini_RGB", "has_rgb": True, "has_ww": False, "has_cw": False, "effect_type": EffectType.SIMPLE, "has_color_order": True, "uses_0x38_effects": True},
 
     # CCT only - no RGB
@@ -913,6 +923,22 @@ def convert_brightness_from_adv(raw_value: int, product_id: int | None) -> int:
     return max(0, min(255, raw_value))
 
 
+def convert_speed_to_inverted_31(speed_pct: int) -> int:
+    """Convert a UI speed percentage (0-100) to the inverted 1-31 protocol byte.
+
+    1 = fastest, 31 = slowest. Used by the 0x38/0x61 effect commands
+    (scene_data_v2 / scene_data, both declare speed min=1 max=31).
+
+    Integer arithmetic is deliberate: the float form
+    ``1 + int(30 * (1.0 - pct / 100))`` truncates the wrong way for values
+    such as 80% (30 * 0.19999999999999996 = 5.999... -> 5), which made the
+    encoder disagree with convert_speed_from_adv() and let the speed drift
+    on every state round-trip.
+    """
+    speed_pct = max(0, min(100, speed_pct))
+    return max(1, min(31, 1 + (30 * (100 - speed_pct)) // 100))
+
+
 def convert_speed_from_adv(raw_value: int, product_id: int | None) -> int:
     """Convert advertisement speed value to 0-100 percentage scale.
 
@@ -926,15 +952,25 @@ def convert_speed_from_adv(raw_value: int, product_id: int | None) -> int:
     scale = get_speed_scale(product_id)
 
     if scale == ValueScale.INVERTED_31:
-        # 0x54/0x55/0x62/0x5B: inverted 0x01-0x1F scale
-        # 0x01 = 100% (fastest), 0x1F = ~3% (slowest)
-        # Formula from model_0x54.py: speed% = round((0x1f - speed_raw) * (100 - 1) / (0x1f - 0x01) + 1)
+        # 0x08/0x3C/0x54/0x55/0x62/0x5B: inverted 0x01-0x1F scale
+        # 0x01 = 100% (fastest), 0x1F = slowest
+        # This must be the exact inverse of the encoder used when sending
+        # (protocol.build_effect_command_0x38 / commands.build_effect_command):
+        #     raw = 1 + int(30 * (1 - pct / 100))
+        # Otherwise the value drifts every time state is read back and fed
+        # into the next effect command.
+        #
+        # Inverting that: raw-1 <= 0.3 * (100 - pct) < raw, so any pct in
+        # (100 - 10*raw/3, 100 - 10*(raw-1)/3] encodes back to the same byte.
+        # Take the top of that interval so decode(encode(pct)) is a fixed point.
         if raw_value < 0x01:
             raw_value = 0x01
         elif raw_value > 0x1F:
             raw_value = 0x1F
-        speed_pct = round((0x1F - raw_value) * 99 / 30 + 1)
-        return max(0, min(100, speed_pct))
+        speed_pct = int(100 - 10 * (raw_value - 1) / 3)
+        # Floor at 1: set_effect() treats a stored speed of 0 as "unset" and
+        # substitutes 50, which would undo the slowest setting
+        return max(1, min(100, speed_pct))
     elif scale == ValueScale.PERCENT:
         # Value is 0-100 percentage
         # Handle potential overflow (device reporting 0-255 when we expect 0-100)

--- a/custom_components/lednetwf_ble/device.py
+++ b/custom_components/lednetwf_ble/device.py
@@ -285,11 +285,17 @@ class LEDNetWFDevice:
 
     @property
     def has_brightness_cmd(self) -> bool:
-        """Return True if device supports the standalone brightness command.
+        """Return True if a brightness-only change can use the 0x3B command.
 
-        These devices declare bright_value_v2 (0x3B 0x01) in ble_devices.json,
-        so brightness can be changed without re-sending the colour or the
-        current effect. Dimmer-only devices always use it.
+        These devices declare bright_value_v2 (0x3B 0x01) in ble_devices.json.
+        The command rescales whatever colour the device currently holds, so it
+        changes brightness without re-sending the colour or re-triggering the
+        running effect. Dimmer-only devices always use it.
+
+        It is ONLY for brightness-only changes. Do not pair it with a colour
+        command: both are write-without-response and the 0x3B lands before the
+        device has committed the colour, re-applying the old one (issue #99).
+        Colour changes carry their own brightness in the scaled RGB.
         """
         return bool(
             self._capabilities.get("has_brightness_cmd")
@@ -1053,11 +1059,10 @@ class LEDNetWFDevice:
             brightness_raw = round(v * 255 / 100)
             if brightness_raw == 0 and (r > 0 or g > 0 or b > 0):
                 brightness_raw = 1
-            # Devices with a separate brightness register are sent pure colour,
-            # so the RGB they report back carries no brightness information.
-            # Deriving brightness from it would snap the slider back to 100%.
-            if not self.has_brightness_cmd:
-                self._brightness = brightness_raw
+            # The device stores the brightness-scaled RGB (a 1% green reports
+            # back as (0,3,0)), so deriving brightness from it via HSV is
+            # correct even when brightness was set with the 0x3B command.
+            self._brightness = brightness_raw
 
             if v > 0 or (r > 0 or g > 0 or b > 0):
                 max_rgb = max(r, g, b)
@@ -1494,17 +1499,6 @@ class LEDNetWFDevice:
                 "IOTBT device: RGB=(%d,%d,%d), brightness=%d%% -> hue-based color",
                 rgb[0], rgb[1], rgb[2], brightness_pct
             )
-        elif eff_type == EffectType.SIMPLE and self.has_brightness_cmd:
-            # SIMPLE device with a separate brightness register (bright_value_v2).
-            # Send the pure colour and let the 0x3B command carry brightness,
-            # the way the app does it. Scaling here as well would dim twice.
-            _LOGGER.debug(
-                "0x31 color command (separate brightness): RGB=(%d,%d,%d), "
-                "brightness=%d sent via 0x3B",
-                rgb[0], rgb[1], rgb[2], brightness
-            )
-
-            packet = protocol.build_color_command_0x31(rgb[0], rgb[1], rgb[2])
         elif eff_type == EffectType.SIMPLE:
             # SIMPLE devices use 0x31 command format (9-byte direct RGB)
             # Brightness is applied directly to RGB values (no separate brightness field)
@@ -1531,17 +1525,14 @@ class LEDNetWFDevice:
                 rgb[0], rgb[1], rgb[2], brightness_pct
             )
 
+        # NOTE: do not follow this up with a 0x3B brightness command. These are
+        # write-without-response, so the second write lands ~1ms later, before
+        # the device has committed the colour. 0x3B re-applies the *previously*
+        # stored colour at the new brightness and cancels the colour change.
+        # Observed in issue #99: repeated "set blue" on a green light only
+        # nudged blue 0 -> 16 -> 28 and never arrived. Brightness belongs in
+        # the scaled RGB above, which is what the device stores anyway.
         if await self._send_command(packet):
-            # Devices with a separate brightness register got a pure colour
-            # above, so follow up with the brightness command
-            if eff_type == EffectType.SIMPLE and self.has_brightness_cmd:
-                brightness_pct = (
-                    max(1, round(brightness * 100 / 255)) if brightness > 0 else 0
-                )
-                await self._send_command(
-                    protocol.build_brightness_command_0x3B(brightness_pct)
-                )
-
             self._rgb = rgb
             self._brightness = brightness
             self._effect = None  # Clear effect when setting color
@@ -2331,11 +2322,6 @@ class LEDNetWFDevice:
                     pure_rgb = (pure_r, pure_g, pure_b)
                 else:
                     pure_rgb = rgb
-
-                # Devices with a separate brightness register are sent pure
-                # colour, so the reported RGB carries no brightness information
-                if self.has_brightness_cmd:
-                    new_brightness = self._brightness
 
                 # The device is showing a solid colour, so any effect we think
                 # is running has ended. Clear it even when the colour itself

--- a/custom_components/lednetwf_ble/device.py
+++ b/custom_components/lednetwf_ble/device.py
@@ -284,6 +284,19 @@ class LEDNetWFDevice:
         return bool(self._capabilities.get("has_dim"))
 
     @property
+    def has_brightness_cmd(self) -> bool:
+        """Return True if device supports the standalone brightness command.
+
+        These devices declare bright_value_v2 (0x3B 0x01) in ble_devices.json,
+        so brightness can be changed without re-sending the colour or the
+        current effect. Dimmer-only devices always use it.
+        """
+        return bool(
+            self._capabilities.get("has_brightness_cmd")
+            or self._capabilities.get("has_dim")
+        )
+
+    @property
     def has_effects(self) -> bool:
         """Return True if device supports effects."""
         return self.effect_type != EffectType.NONE
@@ -913,7 +926,9 @@ class LEDNetWFDevice:
         - White mode: from value1 (byte 5), scaled 0-100 → 0-255
         - Effect mode: from byte 6 (R position), scaled 0-100 → 0-255
         """
-        result = protocol.parse_state_response(data)
+        result = protocol.parse_state_response(
+            data, simple_effects=self.effect_type == EffectType.SIMPLE
+        )
         if not result:
             return
 
@@ -948,7 +963,22 @@ class LEDNetWFDevice:
                 self._effect = self._effect_id_to_name(result["effect_id"])
             self._color_temp_kelvin = None
 
-            if self.effect_type == EffectType.SYMPHONY and self.has_ic_config:
+            if result.get("is_simple_effect_mode"):
+                # SIMPLE devices report the effect ID in mode_type. The meaning
+                # of the remaining bytes in this mode is not yet confirmed for
+                # this family, so deliberately do NOT overwrite brightness or
+                # speed from guessed offsets - that is what previously fed
+                # corrupted values back into the next effect command.
+                # Log the raw bytes so captures can pin the layout down.
+                _LOGGER.debug(
+                    "SIMPLE effect mode: effect_id=%d (0x%02X) -> %s, "
+                    "sub_mode=0x%02X, value1=%d, r=%d, g=%d, b=%d "
+                    "(brightness/speed left unchanged)",
+                    result["effect_id"], result["mode_type"], self._effect,
+                    result["sub_mode"], result["value1"],
+                    result["r"], result["g"], result["b"]
+                )
+            elif self.effect_type == EffectType.SYMPHONY and self.has_ic_config:
                 # True Symphony devices (0xA1-0xAD) effect mode:
                 # - Brightness in byte 6 (R position), 1-100 scale
                 # - Speed in byte 5 (value1), stored as speed_byte × 3
@@ -1018,7 +1048,11 @@ class LEDNetWFDevice:
             brightness_raw = round(v * 255 / 100)
             if brightness_raw == 0 and (r > 0 or g > 0 or b > 0):
                 brightness_raw = 1
-            self._brightness = brightness_raw
+            # Devices with a separate brightness register are sent pure colour,
+            # so the RGB they report back carries no brightness information.
+            # Deriving brightness from it would snap the slider back to 100%.
+            if not self.has_brightness_cmd:
+                self._brightness = brightness_raw
 
             if v > 0 or (r > 0 or g > 0 or b > 0):
                 max_rgb = max(r, g, b)
@@ -1033,8 +1067,8 @@ class LEDNetWFDevice:
             else:
                 self._rgb = (r, g, b)
 
-            _LOGGER.debug("SIMPLE RGB mode (0x61/0x%02X): device_rgb=(%d,%d,%d), pure_rgb=%s, brightness=%d, color_order=%s",
-                          result["sub_mode"], r, g, b, self._rgb, self._brightness, self._color_order)
+            _LOGGER.debug("SIMPLE RGB mode (0x61/0x%02X): device_rgb=(%d,%d,%d), pure_rgb=%s, brightness=%d (derived=%d), color_order=%s",
+                          result["sub_mode"], r, g, b, self._rgb, self._brightness, brightness_raw, self._color_order)
 
         elif (self.effect_type == EffectType.SIMPLE and
               result["mode_type"] == 0x03):
@@ -1455,6 +1489,17 @@ class LEDNetWFDevice:
                 "IOTBT device: RGB=(%d,%d,%d), brightness=%d%% -> hue-based color",
                 rgb[0], rgb[1], rgb[2], brightness_pct
             )
+        elif eff_type == EffectType.SIMPLE and self.has_brightness_cmd:
+            # SIMPLE device with a separate brightness register (bright_value_v2).
+            # Send the pure colour and let the 0x3B command carry brightness,
+            # the way the app does it. Scaling here as well would dim twice.
+            scaled_r, scaled_g, scaled_b = rgb
+
+            _LOGGER.debug(
+                "0x31 color command (separate brightness): RGB=(%d,%d,%d), "
+                "brightness=%d sent via 0x3B",
+                rgb[0], rgb[1], rgb[2], brightness
+            )
         elif eff_type == EffectType.SIMPLE:
             # SIMPLE devices use 0x31 command format (9-byte direct RGB)
             # Brightness is applied directly to RGB values (no separate brightness field)
@@ -1482,6 +1527,16 @@ class LEDNetWFDevice:
             )
 
         if await self._send_command(packet):
+            # Devices with a separate brightness register got a pure colour
+            # above, so follow up with the brightness command
+            if eff_type == EffectType.SIMPLE and self.has_brightness_cmd:
+                brightness_pct = (
+                    max(1, round(brightness * 100 / 255)) if brightness > 0 else 0
+                )
+                await self._send_command(
+                    protocol.build_brightness_command_0x3B(brightness_pct)
+                )
+
             self._rgb = rgb
             self._brightness = brightness
             self._effect = None  # Clear effect when setting color
@@ -1539,29 +1594,39 @@ class LEDNetWFDevice:
         return False
 
     async def set_brightness(self, brightness: int = 255) -> bool:
-        """Set brightness for dimmer-only devices.
+        """Set brightness using the standalone brightness command.
 
-        Uses the 0x3B 0x01 standalone brightness command (bright_value_v2)
-        to control single-channel dimmers (Ctrl_Dim, Bulb_Dim, Magnetic_Dim).
+        Uses the 0x3B 0x01 standalone brightness command (bright_value_v2) to
+        control single-channel dimmers (Ctrl_Dim, Bulb_Dim, Magnetic_Dim) and
+        any other device that declares bright_value_v2 in ble_devices.json.
+
+        On devices that support it this keeps brightness orthogonal to the
+        current mode, so changing brightness does not have to re-send the
+        colour or re-trigger the running effect.
 
         Source: ble_dp_cmd.json bright_value_v2, protocol_docs/05_basic_commands.md
 
         Args:
             brightness: Brightness 0-255 (converted to 0-100 percent for protocol)
         """
-        if not self.has_dim:
-            _LOGGER.warning("Device %s does not support dimmer mode", self._name)
+        if not self.has_brightness_cmd:
+            _LOGGER.warning(
+                "Device %s does not support the standalone brightness command",
+                self._name
+            )
             return False
 
         brightness_pct = max(1, round(brightness * 100 / 255)) if brightness > 0 else 0
-        _LOGGER.debug("Dimmer brightness: %d/255 -> %d%%", brightness, brightness_pct)
+        _LOGGER.debug("Standalone brightness: %d/255 -> %d%%", brightness, brightness_pct)
         packet = protocol.build_brightness_command_0x3B(brightness_pct)
 
         if await self._send_command(packet):
             self._brightness = brightness
-            self._rgb = None
-            self._color_temp_kelvin = None
-            self._effect = None
+            if self.has_dim:
+                # Dimmer-only device: there is no colour or effect to preserve
+                self._rgb = None
+                self._color_temp_kelvin = None
+                self._effect = None
             self._notify_callbacks()
             return True
         return False
@@ -2214,7 +2279,11 @@ class LEDNetWFDevice:
                     self._name
                 )
 
-        result = protocol.parse_manufacturer_data(manu_data, self._name)
+        result = protocol.parse_manufacturer_data(
+            manu_data,
+            self._name,
+            simple_effects=self.effect_type == EffectType.SIMPLE,
+        )
         if not result:
             return False
 
@@ -2257,6 +2326,11 @@ class LEDNetWFDevice:
                     pure_rgb = (pure_r, pure_g, pure_b)
                 else:
                     pure_rgb = rgb
+
+                # Devices with a separate brightness register are sent pure
+                # colour, so the reported RGB carries no brightness information
+                if self.has_brightness_cmd:
+                    new_brightness = self._brightness
 
                 if pure_rgb != self._rgb or new_brightness != self._brightness:
                     self._rgb = pure_rgb

--- a/custom_components/lednetwf_ble/device.py
+++ b/custom_components/lednetwf_ble/device.py
@@ -964,19 +964,24 @@ class LEDNetWFDevice:
             self._color_temp_kelvin = None
 
             if result.get("is_simple_effect_mode"):
-                # SIMPLE devices report the effect ID in mode_type. The meaning
-                # of the remaining bytes in this mode is not yet confirmed for
-                # this family, so deliberately do NOT overwrite brightness or
-                # speed from guessed offsets - that is what previously fed
-                # corrupted values back into the next effect command.
-                # Log the raw bytes so captures can pin the layout down.
+                # SIMPLE devices report the effect ID in mode_type, and the
+                # rest of the response means something different to the
+                # Symphony layout. Confirmed against a device capture (#99):
+                #   value1 (byte 5) = effect speed, inverted 1-31
+                #   r/g/b (bytes 6-8) = the colour the effect is showing right
+                #       now, which changes constantly. NOT brightness or speed.
+                # Brightness is not reported while an effect is running, so it
+                # is deliberately left at whatever we last set.
+                self._effect_speed = convert_speed_from_adv(
+                    result["value1"], self._product_id
+                )
                 _LOGGER.debug(
                     "SIMPLE effect mode: effect_id=%d (0x%02X) -> %s, "
-                    "sub_mode=0x%02X, value1=%d, r=%d, g=%d, b=%d "
-                    "(brightness/speed left unchanged)",
+                    "sub_mode=0x%02X, raw_speed=%d -> %d%%, live_rgb=(%d,%d,%d) "
+                    "(brightness left unchanged at %d)",
                     result["effect_id"], result["mode_type"], self._effect,
-                    result["sub_mode"], result["value1"],
-                    result["r"], result["g"], result["b"]
+                    result["sub_mode"], result["value1"], self._effect_speed,
+                    result["r"], result["g"], result["b"], self._brightness
                 )
             elif self.effect_type == EffectType.SYMPHONY and self.has_ic_config:
                 # True Symphony devices (0xA1-0xAD) effect mode:
@@ -1493,13 +1498,13 @@ class LEDNetWFDevice:
             # SIMPLE device with a separate brightness register (bright_value_v2).
             # Send the pure colour and let the 0x3B command carry brightness,
             # the way the app does it. Scaling here as well would dim twice.
-            scaled_r, scaled_g, scaled_b = rgb
-
             _LOGGER.debug(
                 "0x31 color command (separate brightness): RGB=(%d,%d,%d), "
                 "brightness=%d sent via 0x3B",
                 rgb[0], rgb[1], rgb[2], brightness
             )
+
+            packet = protocol.build_color_command_0x31(rgb[0], rgb[1], rgb[2])
         elif eff_type == EffectType.SIMPLE:
             # SIMPLE devices use 0x31 command format (9-byte direct RGB)
             # Brightness is applied directly to RGB values (no separate brightness field)
@@ -2332,11 +2337,18 @@ class LEDNetWFDevice:
                 if self.has_brightness_cmd:
                     new_brightness = self._brightness
 
+                # The device is showing a solid colour, so any effect we think
+                # is running has ended. Clear it even when the colour itself
+                # has not changed, otherwise a stale effect keeps the colour
+                # picker hidden and makes brightness re-trigger the effect.
+                if self._effect is not None:
+                    self._effect = None
+                    changed = True
+
                 if pure_rgb != self._rgb or new_brightness != self._brightness:
                     self._rgb = pure_rgb
                     self._brightness = new_brightness
                     self._color_temp_kelvin = None  # Clear CCT when in RGB mode
-                    self._effect = None  # Clear effect when in RGB mode
                     changed = True
                     _LOGGER.debug("Advertisement updated RGB: device_rgb=(%d,%d,%d), pure_rgb=%s, brightness=%d (HSV v=%d)",
                                   r, g, b, self._rgb, self._brightness, v)

--- a/custom_components/lednetwf_ble/light.py
+++ b/custom_components/lednetwf_ble/light.py
@@ -215,8 +215,13 @@ class LEDNetWFLight(LightEntity):
             # so user can adjust foreground color while staying in the effect
             if self._device.is_in_settled_effect():
                 return ColorMode.RGB
-            # For other effects, report brightness mode (no color picker)
-            return ColorMode.BRIGHTNESS
+            # For other effects there is no meaningful colour to report.
+            # Only claim BRIGHTNESS if we actually declared it as supported:
+            # HA rejects a color_mode that is not in supported_color_modes,
+            # which leaves the entity with no colour picker at all. RGB-only
+            # devices fall through to the normal handling below.
+            if ColorMode.BRIGHTNESS in self._attr_supported_color_modes:
+                return ColorMode.BRIGHTNESS
         if self._device.color_temp_kelvin and self._device.has_color_temp:
             return ColorMode.COLOR_TEMP
         if self._device.rgb_color and self._device.has_rgb:

--- a/custom_components/lednetwf_ble/light.py
+++ b/custom_components/lednetwf_ble/light.py
@@ -240,10 +240,13 @@ class LEDNetWFLight(LightEntity):
             brightness = self._device.brightness or 255
 
         # Handle effect
+        # Pass brightness through: HA scenes send effect and brightness in the
+        # same call, and previously the brightness was silently dropped, so
+        # applying a scene did not reproduce the state it captured.
         if ATTR_EFFECT in kwargs:
             effect = kwargs[ATTR_EFFECT]
             if effect:
-                await self._device.set_effect(effect)
+                await self._device.set_effect(effect, brightness=brightness)
                 return
 
         # Handle color temperature
@@ -259,7 +262,13 @@ class LEDNetWFLight(LightEntity):
         # Just brightness change - resend current color/mode
         # IMPORTANT: Check effect FIRST since it takes priority over stored color values
         if ATTR_BRIGHTNESS in kwargs:
-            if self._device.effect:
+            if self._device.has_brightness_cmd:
+                # Device has a standalone brightness command (bright_value_v2),
+                # so brightness can be changed without disturbing the current
+                # colour or effect. Avoids re-sending the effect, which is what
+                # made brightness changes jump into an effect on 0x08/0x3C.
+                await self._device.set_brightness(brightness)
+            elif self._device.effect:
                 # Re-send effect with new brightness
                 await self._device.set_effect(
                     self._device.effect,

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -13,7 +13,13 @@ import colorsys
 import logging
 from typing import Tuple
 
-from .const import EffectType, MIN_KELVIN, MAX_KELVIN, SYMPHONY_BG_COLOR_EFFECTS
+from .const import (
+    EffectType,
+    MIN_KELVIN,
+    MAX_KELVIN,
+    SYMPHONY_BG_COLOR_EFFECTS,
+    convert_speed_to_inverted_31,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1037,9 +1043,7 @@ def build_candle_command(
     Note: Speed is inverted like SIMPLE effects: 1=fastest, 31=slowest
     """
     # Convert UI speed (0-100, 100=fast) to protocol speed (1-31, 1=fast)
-    # Formula: 1 + (30 * (1.0 - speed/100))
-    speed_byte = 1 + int(30 * (1.0 - max(0, min(100, speed)) / 100))
-    speed_byte = max(1, min(31, speed_byte))
+    speed_byte = convert_speed_to_inverted_31(speed)
 
     brightness = max(1, min(100, brightness))
 
@@ -1108,8 +1112,7 @@ def build_effect_command_0x38(
     Note: Speed is inverted like 0x61: 1=fastest, 31=slowest
     """
     # Convert UI speed (0-100, 100=fast) to protocol speed (1-31, 1=fast)
-    speed_byte = 1 + int(30 * (1.0 - max(0, min(100, speed)) / 100))
-    speed_byte = max(1, min(31, speed_byte))
+    speed_byte = convert_speed_to_inverted_31(speed)
 
     brightness = max(1, min(100, brightness))
 
@@ -1243,8 +1246,7 @@ def build_effect_command(
             # Formula from ad/e.java: protocol_speed = 1 + (30 * (1.0 - ui_speed/100))
             # 100% UI speed (fast) → 1 (fastest protocol value)
             # 0% UI speed (slow) → 31 (slowest protocol value)
-            speed_byte = 1 + int(30 * (1.0 - speed / 100))
-            speed_byte = max(1, min(31, speed_byte))  # Clamp to valid range
+            speed_byte = convert_speed_to_inverted_31(speed)
             return build_effect_command_0x61(effect_id, speed_byte)
     return None
 
@@ -1493,9 +1495,17 @@ def build_sound_reactive_symphony(
 # RESPONSE PARSING
 # =============================================================================
 
-def parse_state_response(data: bytes) -> dict | None:
+def parse_state_response(data: bytes, simple_effects: bool = False) -> dict | None:
     """
     Parse state query response (0x81 format).
+
+    Args:
+        data: Raw 0x81 response
+        simple_effects: True when the device uses SIMPLE effects (IDs 37-56).
+            Those devices report the running effect ID directly in the mode_type
+            byte instead of using the 0x25 "effect mode" marker with the ID in
+            sub_mode. Effect 37 is 0x25, so the two encodings collide on the
+            first effect in the list and must be disambiguated by device type.
 
     Source: tc/b.java method c() lines 47-62, DeviceState.java
     Source: protocol_docs/08_state_query_response_parsing.md
@@ -1540,9 +1550,17 @@ def parse_state_response(data: bytes) -> dict | None:
 
     # Byte 3: Mode type
     # 0x61 (97) = static color/white mode
-    # 0x25 (37) = effect mode
+    # 0x25 (37) = effect mode (Symphony/Addressable - effect ID is in sub_mode)
+    # 37-56    = SIMPLE effect mode - mode_type IS the effect ID
     mode_type = data[3]
-    is_effect_mode = mode_type == 0x25
+
+    # SIMPLE devices report the effect ID in mode_type. Only trust that reading
+    # when the caller told us this is a SIMPLE device, otherwise 0x25 keeps its
+    # original meaning for Symphony/Addressable devices.
+    is_simple_effect_mode = simple_effects and 37 <= mode_type <= 56
+    is_effect_mode = is_simple_effect_mode or (
+        not simple_effects and mode_type == 0x25
+    )
 
     # Byte 4: Sub-mode
     # In static mode: 0xF0/0x01/0x0B = RGB, 0x0F = white
@@ -1575,13 +1593,20 @@ def parse_state_response(data: bytes) -> dict | None:
     led_version = data[10]  # This is LED/firmware version, NOT brightness
     cw = data[11]
 
-    # Effect ID is sub_mode when in effect mode
-    effect_id = sub_mode if is_effect_mode else None
+    # Effect ID is sub_mode when in effect mode, except for SIMPLE devices
+    # where mode_type itself is the effect ID
+    if is_simple_effect_mode:
+        effect_id = mode_type
+    elif is_effect_mode:
+        effect_id = sub_mode
+    else:
+        effect_id = None
 
     return {
         "is_on": is_on,
         "mode_type": mode_type,
         "sub_mode": sub_mode,
+        "is_simple_effect_mode": is_simple_effect_mode,
         "value1": value1,
         "r": r,
         "g": g,
@@ -1791,7 +1816,8 @@ def product_id_from_name(device_name: str | None) -> int | None:
 
 def parse_manufacturer_data(
     manu_data: dict[int, bytes],
-    device_name: str | None = None
+    device_name: str | None = None,
+    simple_effects: bool = False,
 ) -> dict | None:
     """
     Parse manufacturer data from BLE advertisement (Format B - bleak).
@@ -1813,6 +1839,10 @@ def parse_manufacturer_data(
     Args:
         manu_data: Manufacturer data dict from BLE advertisement
         device_name: Optional device name for log message context
+        simple_effects: True when the device uses SIMPLE effects (IDs 37-56),
+            which report the running effect ID in the mode_type byte rather
+            than via the 0x25 effect-mode marker. Effect 37 is 0x25, so the
+            encodings collide and must be disambiguated by device type.
 
     Returns dict with:
         - product_id: int
@@ -2105,6 +2135,32 @@ def parse_manufacturer_data(
                         "state_bytes[14:24]: %s",
                         log_prefix, sub_mode, state_bytes
                     )
+            elif simple_effects and 37 <= mode_type <= 56:
+                # SIMPLE effect mode - mode_type IS the effect ID (37-56).
+                # Checked before the 0x25 branch below because effect 37 is
+                # 0x25 and would otherwise be decoded as "effect mode" with the
+                # ID taken from sub_mode (which is not an effect ID here).
+                color_mode = 'effect'
+                effect_id = mode_type
+                brightness_percent = data[17] if data[17] <= 100 else None
+
+                # sub_mode is not reliably the speed on these devices - it is
+                # often an echo of the power state (0x23=ON, 0x24=OFF). Only
+                # treat it as a speed value when it is not a power-state byte.
+                # Scaling (inverted 1-31 vs percent) is applied by the caller
+                # via convert_speed_from_adv().
+                if sub_mode in (0x23, 0x24):
+                    effect_speed = None
+                else:
+                    effect_speed = sub_mode
+
+                state_bytes = ' '.join(f'{b:02X}' for b in data[14:min(25, len(data))])
+                _LOGGER.debug(
+                    "%sManu data SIMPLE effect mode: id=%d (0x%02X), sub_mode=0x%02X, "
+                    "bright_pct=%s, raw_speed=%s, state_bytes[14:24]: %s",
+                    log_prefix, effect_id, mode_type, sub_mode,
+                    brightness_percent, effect_speed, state_bytes
+                )
             elif mode_type == 0x25:
                 # Effect mode - interpretation depends on device type
                 # For Symphony/Addressable: sub_mode is the effect ID directly

--- a/custom_components/lednetwf_ble/protocol.py
+++ b/custom_components/lednetwf_ble/protocol.py
@@ -2092,7 +2092,21 @@ def parse_manufacturer_data(
 
             if mode_type == 0x61:
                 # Color or white mode
-                if sub_mode in (0xF0, 0x01, 0x0B):
+                if simple_effects and sub_mode == 0x23:
+                    # SIMPLE devices echo the power state into sub_mode instead
+                    # of a colour-mode marker, so 0x61 + 0x23 is solid colour
+                    # with the RGB in bytes 18-20, not standby.
+                    # Confirmed against a device capture (issue #99).
+                    # Power state comes from data[14] and is handled separately.
+                    # 0x24 (off) is left to the existing handling below - the
+                    # colour bytes are not meaningful with the light off.
+                    color_mode = 'rgb'
+                    rgb = (data[18], data[19], data[20])
+                    _LOGGER.debug(
+                        "%sManu data SIMPLE solid colour (0x61/0x%02X): rgb=%s",
+                        log_prefix, sub_mode, rgb
+                    )
+                elif sub_mode in (0xF0, 0x01, 0x0B):
                     # RGB mode (0xF0=RGB, 0x01/0x0B may be effects/music mode but show as RGB)
                     color_mode = 'rgb'
                     rgb = (data[18], data[19], data[20])
@@ -2140,26 +2154,27 @@ def parse_manufacturer_data(
                 # Checked before the 0x25 branch below because effect 37 is
                 # 0x25 and would otherwise be decoded as "effect mode" with the
                 # ID taken from sub_mode (which is not an effect ID here).
+                #
+                # Layout confirmed against a device capture (issue #99). The
+                # advertisement state block mirrors the 0x81 response from
+                # byte 2 onwards:
+                #   data[16] = sub_mode, always an echo of the power state
+                #              (0x23=ON, 0x24=OFF), NOT the speed
+                #   data[17] = value1 = effect speed, inverted 1-31
+                #   data[18:21] = the live colour the effect is currently
+                #              showing, NOT brightness/speed parameters
+                # Brightness is not reported at all while an effect runs.
                 color_mode = 'effect'
                 effect_id = mode_type
-                brightness_percent = data[17] if data[17] <= 100 else None
-
-                # sub_mode is not reliably the speed on these devices - it is
-                # often an echo of the power state (0x23=ON, 0x24=OFF). Only
-                # treat it as a speed value when it is not a power-state byte.
-                # Scaling (inverted 1-31 vs percent) is applied by the caller
-                # via convert_speed_from_adv().
-                if sub_mode in (0x23, 0x24):
-                    effect_speed = None
-                else:
-                    effect_speed = sub_mode
+                brightness_percent = None
+                effect_speed = data[17]
 
                 state_bytes = ' '.join(f'{b:02X}' for b in data[14:min(25, len(data))])
                 _LOGGER.debug(
                     "%sManu data SIMPLE effect mode: id=%d (0x%02X), sub_mode=0x%02X, "
-                    "bright_pct=%s, raw_speed=%s, state_bytes[14:24]: %s",
-                    log_prefix, effect_id, mode_type, sub_mode,
-                    brightness_percent, effect_speed, state_bytes
+                    "raw_speed=%d, live_rgb=(%d,%d,%d), state_bytes[14:24]: %s",
+                    log_prefix, effect_id, mode_type, sub_mode, effect_speed,
+                    data[18], data[19], data[20], state_bytes
                 )
             elif mode_type == 0x25:
                 # Effect mode - interpretation depends on device type

--- a/protocol_docs/08_state_query_response_parsing.md
+++ b/protocol_docs/08_state_query_response_parsing.md
@@ -50,6 +50,14 @@ Never use this byte for brightness calculations.
 | 37    | 0x25 | Effect mode (Symphony/Addressable - effect ID in sub-mode) |
 | 37-56 | 0x25-0x38 | SIMPLE effect mode - mode_type IS the effect ID |
 
+> **These two rows overlap and cannot be told apart from the response alone.**
+> Effect 37 (the first SIMPLE effect) is 0x25, the same value Symphony and
+> Addressable devices use as the effect-mode marker. The device type must
+> decide which reading applies: parse as a SIMPLE effect ID when the device
+> uses SIMPLE effects, otherwise as the 0x25 marker with the ID in sub-mode.
+> Getting this wrong reports effect 37 as some other effect entirely.
+> See `ai_instructions/DISCOVERIES.md` and issue #99.
+
 **SIMPLE Effect Mode (mode_type 37-56):**
 For SIMPLE devices (e.g., product_id 0x33), when running effects like "Yellow gradual change"
 (effect 41 = 0x29), the mode_type byte directly contains the effect ID rather than a mode

--- a/protocol_docs/08_state_query_response_parsing.md
+++ b/protocol_docs/08_state_query_response_parsing.md
@@ -61,13 +61,29 @@ Never use this byte for brightness calculations.
 **SIMPLE Effect Mode (mode_type 37-56):**
 For SIMPLE devices (e.g., product_id 0x33), when running effects like "Yellow gradual change"
 (effect 41 = 0x29), the mode_type byte directly contains the effect ID rather than a mode
-indicator. The sub-mode byte may contain speed or other parameters.
+indicator.
 
-Example: Device running "Yellow gradual change" reports:
+Confirmed against a product 0x08 capture (issue #99), all checksums verified:
 
-- mode_type = 0x29 (41) = effect ID
-- sub_mode = 0x23 (35) = possibly speed
-- byte 17 = brightness percentage
+| Byte | Meaning |
+|------|---------|
+| 3 | Effect ID (37-56) |
+| 4 | Sub-mode: **echo of the power state** (0x23=ON, 0x24=OFF), not a parameter |
+| 5 | **Effect speed, inverted 1-31** (1 = fastest) |
+| 6-8 | The colour the effect is showing at that instant, changes constantly |
+
+Byte 5 was verified by sending three known speeds and reading the response
+back: `38 25 10 1E` → value1 0x10, `38 25 01 01` → value1 0x01,
+`38 25 1F 01` → value1 0x1F.
+
+> **Brightness is NOT reported while an effect is running.** An earlier version
+> of this document said byte 6 held the brightness in effect mode. That is
+> wrong for this family: byte 6 is the red channel of the live effect colour.
+> Treat brightness as unknown and keep the last commanded value.
+
+The same applies to solid colour on these devices: sub-mode is the power-state
+echo rather than one of the colour-mode markers in the table below, and the
+RGB is in bytes 6-8 as usual.
 
 ### Sub-mode (Byte 4) Values (when Mode Type = 0x61)
 

--- a/protocol_docs/08_state_query_response_parsing.md
+++ b/protocol_docs/08_state_query_response_parsing.md
@@ -72,9 +72,11 @@ Confirmed against a product 0x08 capture (issue #99), all checksums verified:
 | 5 | **Effect speed, inverted 1-31** (1 = fastest) |
 | 6-8 | The colour the effect is showing at that instant, changes constantly |
 
-Byte 5 was verified by sending three known speeds and reading the response
-back: `38 25 10 1E` → value1 0x10, `38 25 01 01` → value1 0x01,
-`38 25 1F 01` → value1 0x1F.
+Byte 5 was verified by pairing outbound `38{model}{speed}{bright}` commands
+with the response they produced. A pair only discriminates when speed and
+bright differ: `38 25 10 1E` (speed 16, bright 30) → value1 16, and
+`38 25 1F 01` (speed 31, bright 1) → value1 31. Both match the speed. A third
+pair, `38 25 01 01`, has both fields set to 1 and so proves nothing.
 
 > **Brightness is NOT reported while an effect is running.** An earlier version
 > of this document said byte 6 held the brightness in effect mode. That is


### PR DESCRIPTION
Fixes the erratic control reported for `Ctrl_Mini_RGB_Mic` in #99. Confirmed working by the reporter on real hardware (product 0x08) after two rounds of testing.

The root cause was never the commands. The device's own state was being parsed wrongly, and the bad values were then fed into the *next* command. That's why the reporter found they could work around it by changing several settings in quick succession, before the state feedback landed.

## Fixes

**Effect ID 37 collides with the 0x25 effect-mode marker.** SIMPLE devices report the running effect ID in `mode_type` (37-56). Effect 37 is 0x25, which is also the marker Symphony devices use with the ID in `sub_mode`. Both parsers assumed the Symphony meaning, so a device running effect 37 was reported as effect 55 with its speed read out of an RGB byte, and effects 38-56 weren't recognised as effect mode at all. Both parsers now take a `simple_effects` flag from the caller.

**Speed drifted on every state round-trip.** Two independent causes. 0x08/0x3C send effects with the inverted 1-31 encoding (`scene_data_v2` declares speed min=1 max=31) but were missing from `INVERTED_SPEED_PRODUCT_IDS`, so the value read back was treated as a percentage. Separately the encoder `1 + int(30 * (1.0 - pct / 100))` truncates the wrong way for some values because of float representation (at 80%, `30 * 0.19999999999999996` = 5.999… → 5). Added `convert_speed_to_inverted_31()` using integer arithmetic and made the decoder its exact inverse, so `decode(encode(pct))` is a fixed point for all of 1-100.

**Brightness had to re-send the effect.** `light.py` re-sent the current effect on any brightness change, so a wrong effect in the state meant the brightness slider pulled the light into it. These devices declare `bright_value_v2` (0x3B 0x01), so a brightness-only change now uses that and leaves colour and effect alone.

**Advertisements didn't recognise solid colour.** 0x61 with `sub_mode` 0x23 was read as "standby" and discarded, so the colour was never learned from an advert. It means solid colour with the RGB in bytes 18-20. A solid-colour advert now also clears a stale effect, so it can't keep the colour picker hidden.

**An RGB-only device reported an unsupported colour mode.** `light.py` returned `ColorMode.BRIGHTNESS` whenever an effect ran, but RGB-only devices never declare `BRIGHTNESS` as supported, and HA rejects a `color_mode` outside `supported_color_modes` — leaving the entity with no colour picker at all.

**Product 0x3C added.** Same `Ctrl_Mini_RGB_Mic` as 0x08 with an identical function list in `ble_devices.json`, but no entry, so it fell through to the unknown-product fallback that assumes `EffectType.SYMPHONY`.

**Scenes dropped brightness.** `turn_on` returned early on `ATTR_EFFECT`, discarding the brightness HA sends in the same call.

## Protocol findings

An nRF capture plus the debug logs pinned down the SIMPLE state layout, which the docs had partly wrong. Recorded in `ai_instructions/DISCOVERIES.md` and `protocol_docs/08_state_query_response_parsing.md`:

- Byte 5 (`value1`) is the **effect speed**, inverted 1-31. Verified by pairing sent commands with responses where speed and brightness differ.
- Byte 4 is an echo of the power state, never a parameter.
- Bytes 6-8 are the colour the effect is showing at that instant. The docs previously claimed byte 6 was the brightness in effect mode, which is wrong.
- **Brightness is not reported at all while an effect runs.** Confirmed by controlled test: brightness set to 15% with an effect running, and the advertisement came back byte-for-byte identical. Brightness changed by an IR remote or the app therefore cannot be detected mid-effect.
- In effect mode the reported RGB is at full intensity, not brightness-scaled. Solid-colour mode is the opposite.

## Note for reviewers

Two regressions were introduced and fixed during testing, both worth knowing about:

1. A new branch in `set_rgb_color` set up its locals but never assigned `packet`, because that assignment lives inside the following branch rather than after the chain. Every colour change raised `UnboundLocalError`.
2. Pairing the 0x3B brightness command with the 0x31 colour command broke colour entirely. Both are write-without-response, so the 0x3B landed ~1ms later, before the device had committed the colour, and rescaled the colour it still held. A green light asked three times for pure blue only crept 0 → 16 → 28. Colour now carries its brightness in the scaled RGB and sends a single command, as before. `has_brightness_cmd` is strictly for brightness-*only* changes.

## Testing

Verified by the reporter on hardware: colour, brightness, effects, effect speed, brightness while in an effect, exiting effects, and Home Assistant scenes — including reapplying a scene after deliberately changing settings in between, which was the hardest of the original symptoms to reason about.

Closes #99